### PR TITLE
[codex] publish Overland Track hiking guide

### DIFF
--- a/.claude/skills/annotating-hike-photos/SKILL.md
+++ b/.claude/skills/annotating-hike-photos/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: annotating-hike-photos
+description: Use when placing, captioning, or auto-tagging uploaded hike photos on benebsworth.com — running the tools/hike-annotate pipeline (or its hike-annotate MCP) that classifies each photo with the Antigravity CLI (agy, Gemini vision), geo-matches it to the hike's waypoints, and writes slot/caption/alt into the GCS gallery manifest. Also the reference for the child-CLI-orchestration + MCP-for-images pattern. Part of the hiking workflow; for authoring the guide itself use writing-trail-guides.
+---
+
+# Annotating hike photos
+
+After photos are uploaded via `/admin` from a specific hike (which extracts EXIF
+geo at upload and stores them under `assets/hike/<slug>/`), each still needs
+**placing** (assigned to a waypoint) and **captioning**. The
+`tools/hike-annotate` pipeline does this automatically: it reads both the hike's
+manifest and the namespaced library assets, classifies every photo with **`agy`**
+(Antigravity CLI, Gemini vision), geo-matches it to the hike's waypoints, and
+writes `slot` + `caption` + `alt` (+ a hero) back to the GCS manifest — turning
+~an hour of manual tagging into a review-and-confirm.
+
+## When to use
+- A hike has uploaded gallery photos that are unplaced (`slot` empty) — e.g. after a
+  batch upload in `/admin`.
+- You want to (re-)caption or (re-)place a hike's gallery.
+- You need the reusable pattern for orchestrating an agentic child CLI (agy) for
+  vision, or the `hike-annotate` MCP — see `child-cli-orchestration.md`.
+
+For authoring the long-form trail guide itself, use **writing-trail-guides**.
+
+## How it works (6 stages)
+1. Read `manifest/hike/<slug>.json` from GCS (public-read).
+2. Geocode the hike's waypoint names → real lat/lng (Haute Route seeded; Nominatim, cached).
+3. Geo-match each photo by its EXIF `lat`/`lng` → nearest waypoint (+ a chronology check).
+4. Classify each photo with `agy` → `caption`, `alt`, `sceneType`, `subjectTags`,
+   `waypoint` (scene can override noisy GPS — the Matterhorn ⇒ Zermatt), `heroWorthiness`,
+   `quality`, `skip`.
+5. Merge geo + scene → `slot` (the waypoint NAME), `caption`, `alt`; order
+   chronologically; pick a landscape hero.
+6. Propose (annotated manifest + an HTML thumbnail report) → **review** → write on approval.
+
+`slot` MUST equal a waypoint `name` exactly — the public gallery filters by
+`asset.slot === waypoint.name` when you click a journey-map waypoint (no waypoint id).
+
+## Run it (CLI)
+```bash
+# dry-run: classify + place all photos, write a review report, cache the proposal
+node tools/hike-annotate/bin/annotate.mjs <slug> --hint "<Country>" --concurrency 5
+
+# review the proposal
+open tools/hike-annotate/.cache/proposals/<slug>/report.html
+
+# apply the EXACT reviewed proposal to the live manifest (no re-classify)
+node tools/hike-annotate/bin/annotate.mjs <slug> --apply
+# also: --write (re-classify + write in one go) · --limit N (trial run) · --yes (skip prompt)
+```
+
+## Run it (MCP)
+The `hike-annotate` MCP (in the local `.mcp.json`, loads on reconnect) exposes:
+`list_hikes_with_photos` · `propose_annotations({slug, limit?, hint?})` ·
+`get_proposal_report({slug})` · `write_manifest({slug, confirm:true})`. Same
+review-then-write discipline — `write_manifest` refuses without `confirm:true` or on a
+partial proposal, and writes the exact cached proposal.
+
+## Prerequisites
+- **`agy`** logged in (`~/.local/bin/agy`, Antigravity, Google AI Pro). The free
+  `gemini` CLI login no longer works (`IneligibleTierError` → migrate to Antigravity).
+- **`gcloud`/`gsutil`** authed as the bucket owner (`ben.ebsworth@gmail.com`, bucket
+  `benebsworth-hiking`) — the tool pins the account for writes.
+
+## Discipline
+- It is a **live production write** to the gallery manifest (the site reads it live).
+  Always dry-run → review the report → apply. The write is additive (the fields are
+  blank today) and backs up the current manifest locally first.
+- Sparse town waypoints mean photos taken on the high *in-between* days land on the
+  nearest town; tweak any `slot`/`caption` in `/admin` afterwards.
+
+See `child-cli-orchestration.md` (next to this file) for the reusable agy + MCP image
+pattern and its gotchas.

--- a/.claude/skills/annotating-hike-photos/child-cli-orchestration.md
+++ b/.claude/skills/annotating-hike-photos/child-cli-orchestration.md
@@ -1,0 +1,77 @@
+# Orchestrating an agentic child CLI for image classification
+
+The reusable pattern `tools/hike-annotate` uses to drive **`agy`** (the Antigravity
+CLI, Gemini vision) as a headless image classifier from Node — and when to wrap it as
+an MCP. Generalises to any agentic CLI you want to use as a structured-output worker.
+
+## The `agy` invocation
+```bash
+agy --add-dir <imageDir> --dangerously-skip-permissions -p '<prompt>'
+```
+- `-p` / `--print` — headless one-shot (prints the response; no interactive session).
+- `--add-dir <dir>` — give agy file access to the dir holding the image, then reference
+  the image by absolute path in the prompt ("Look at the image file /tmp/.../x.webp").
+- `--dangerously-skip-permissions` — don't block on tool-permission prompts.
+- `--model` optional; default is the account's model (Gemini 3.x Pro under AI Pro).
+
+## CRITICAL gotcha — close stdin
+`agy` (like many agentic CLIs) **blocks on an open stdin pipe**. Node's `execFile`
+leaves stdin open, so the call hangs until timeout. Use `spawn` with stdin ignored:
+```js
+import { spawn } from 'node:child_process'
+const child = spawn('agy', args, { stdio: ['ignore', 'pipe', 'pipe'] }) // 'ignore' = closed stdin
+```
+(From a shell, `printf '' | agy …` has the same effect — closing stdin is what matters.)
+
+## Strict-JSON contract
+Agentic CLIs may wrap output in prose or code fences. So:
+- Prompt: *"Return ONLY a JSON object — no prose, no markdown fence — with EXACTLY these keys: …"*.
+- Parse defensively: strip ```` ``` ```` fences, then scan for the first **balanced**
+  `{…}` (track brace depth — a naive `indexOf('{')`…`lastIndexOf('}')` breaks on nested
+  objects) and `JSON.parse` it.
+- One retry with "Return ONLY the JSON object" appended; then mark `needsManual` and
+  continue the batch rather than aborting.
+- Validate/clamp every field — enum the `sceneType`, ensure the returned `waypoint` is a
+  real waypoint name, clamp 0–10 scores. Never trust the model's shape.
+
+## Throughput
+~15–20 s per image. Run a small concurrency pool (≈5 concurrent `spawn`s) — each call
+is a separate process. Classify the small `*-thumb.webp` (≈40 KB), not the full image.
+Covered by AI Pro (no per-call billing), but mind rate limits; expose `--concurrency`
+and `--limit N` for trial runs.
+
+## Feed geo + context into the prompt
+The geo half is deterministic (haversine to geocoded waypoints) and is a strong prior.
+Pass the geo-nearest candidates + the full ordered route into the prompt so the model
+picks among *plausible* waypoints and can override a noisy GPS by scene (e.g. it sees
+the Matterhorn ⇒ Zermatt). Tell it not to invent place names it cannot actually see.
+
+## Reading repo TypeScript data from a plain Node tool
+The waypoints live in `content/hiking.ts` (TypeScript). A standalone `.mjs` tool reads
+it with `node --experimental-strip-types` — its only import is type-only (`import type`),
+which strips cleanly, so no path-alias resolution is needed. Spawn a child:
+`node --experimental-strip-types --input-type=module -e "import {getHike} from 'file://…/content/hiking.ts'; …"`.
+
+## CLI vs MCP
+- **CLI** (`bin/annotate.mjs`) — for running the batch + the review-then-write flow
+  directly; it caches the proposal so `--apply` writes exactly what was reviewed.
+- **MCP** (`mcp/server.mjs`) — wrap the same core so Claude can drive it across a
+  session: `propose_annotations` → inspect the report path → `write_manifest({confirm:true})`.
+  Statefulness between calls comes from the shared proposal cache
+  (`.cache/proposals/<slug>/`). Register the server's absolute path in a **local,
+  untracked** `.mcp.json` (machine-specific paths shouldn't be committed); it loads on
+  the next Claude reconnect.
+
+## Auth separation (keep the two explicit)
+- **Model**: `agy` has its own login (Antigravity / Google AI Pro). The dead path is the
+  free `gemini` CLI Code-Assist login (`IneligibleTierError`).
+- **Storage write**: pinned gcloud — `CLOUDSDK_CORE_ACCOUNT=ben.ebsworth@gmail.com gsutil
+  -h "Cache-Control:no-store" cp … gs://benebsworth-hiking/manifest/hike/<slug>.json`.
+  Never rely on the ambient gcloud active account.
+
+## Review-then-write is non-negotiable
+Writing the gallery manifest is a live production write. The pipeline always produces a
+**proposal + a visual report** first; the actual GCS write is a separate, confirm-gated
+step (CLI `--apply`/`--write` with a `yes` prompt; MCP `write_manifest` requires
+`confirm:true` and refuses a partial proposal). It backs up the current manifest locally
+before overwriting.

--- a/components/admin/admin-shell.tsx
+++ b/components/admin/admin-shell.tsx
@@ -113,7 +113,7 @@ export function AdminShell({ items }: { items: { blogs: CrmItem[]; hikes: CrmIte
 
   const uploadFiles = useCallback(
     async (files: FileList | null): Promise<Asset[]> => {
-      if (!files?.length || !getToken) return []
+      if (!files?.length || !getToken || !selItem) return []
       setError(null)
       const added: Asset[] = []
       try {
@@ -134,7 +134,7 @@ export function AdminShell({ items }: { items: { blogs: CrmItem[]; hikes: CrmIte
           if (!f.type.startsWith('image/')) continue
           setBusy(`Uploading ${i + 1}/${files.length}…`)
           try {
-            added.push(await uploadAsset(f, token, stamp + i))
+            added.push(await uploadAsset(f, token, stamp + i, selItem.type, selItem.slug))
           } catch (e) {
             // stop the batch, but STILL record what already reached the bucket
             // below — otherwise files 1..N-1 become orphaned GCS objects that
@@ -164,7 +164,7 @@ export function AdminShell({ items }: { items: { blogs: CrmItem[]; hikes: CrmIte
         setBusy(null)
       }
     },
-    [getToken, libLoaded],
+    [getToken, libLoaded, selItem],
   )
 
   const pick = useCallback((multi: boolean): Promise<Asset[]> => {

--- a/content/blog/overland-track-guide/index.mdx
+++ b/content/blog/overland-track-guide/index.mdx
@@ -1,99 +1,146 @@
 ---
-title: "The Overland Track — a trail guide"
+title: "The Overland Track in winter — a trail guide"
 date: 2026-06-29
-description: "Tasmania's great alpine walk, end to end: six days from Cradle Mountain to Lake St Clair, the huts you sleep in, the summits worth the detour, and what grows and moves in the oldest wilderness in Australia."
+description: "Tasmania's great alpine walk in the quiet of winter: eight days from Cradle Mountain to Lake St Clair, walking through snow, summiting side peaks, and staying in the empty huts."
 labels: hiking, trail-guide
-release: false
+release: true
 heroImage: /blog/overland-track-guide/hero.webp
 takeaways:
-  - "Sixty-five kilometres, six days, one direction. The core route is a string of six huts from Cradle Mountain south to Lake St Clair, with the hardest climb on the very first morning and the rest a long gentle shedding of altitude."
-  - "The best of the track is optional. Mount Ossa, Barn Bluff, the Du Cane waterfalls and Pine Valley are all side trips off the main line — the walkers who carry light and detour often see twice as much as those who only tick the huts."
-  - "This is Gondwana, not the Alps. Pandani, deciduous beech and thousand-year-old King Billy pines grow nowhere else, and it can snow in any month — pack for winter even in February."
+  - "The Overland Track is usually a six-day summer walk, but in winter it becomes a slower, snowier, far quieter trip. Give yourself eight days if you want to climb the side peaks without rushing."
+  - "Black ice, hard snow and short days change the rhythm. Microspikes and a four-season sleeping bag are not optional; neither is patience when the shuttle can't run."
+  - "The side trips are the reason you come. Mount Oakleigh at sunrise, Mount Ossa on a clear day, and a frozen Lake Windermere reflecting Barn Bluff were the moments that stuck."
 ---
 
-The Overland Track is the walk most Australian hikers measure the others against. Sixty-five kilometres through the heart of the Cradle Mountain–Lake St Clair National Park, a slice of the Tasmanian Wilderness World Heritage Area, walked north to south over six unhurried days. You start beneath the serrated profile of Cradle Mountain and finish on the shore of the deepest natural lake in Australia, and in between you cross button-grass moorland, climb past glacial tarns, drop into rainforest older than the species walking through it, and sleep in a chain of well-built huts.
+I walked the Overland Track in mid-winter, at the end of July, when the booking quota is gone, the huts are almost empty, and the track can feel like it belongs to the people on it. A few weeks earlier I had used a six-hour hike up Mount Riddell, just outside Melbourne, as a warm-up. It was not enough. I was under-trained and a little de-conditioned, and I knew it. The one thing I had sorted was footwear: a pair of [Meindl Guffert boots](https://meindl.com.au/collections/all-mens-boots/products/guffert) that turned out to be worth every dollar on the frozen boardwalks and icy rock of the plateau.
 
-What makes it special is not difficulty. The main track is graded moderate and most of the real climbing is over by lunchtime on day one. What makes it special is the density of good things per kilometre, and the fact that so many of the best of them sit just off the line, waiting for anyone willing to drop their pack at a junction and walk an extra hour uphill. This guide lays out the route as it is usually walked, the side trips worth the legs, where you sleep, and what you are likely to see growing and moving around you.
+The standard Overland is a one-way, six-day summer traverse from Ronny Creek to Narcissus Hut, where most people ferry down Lake St Clair. In winter the days are short, the side trips take longer, and the huts are cold enough that you want to arrive with light left to make dinner. I stretched it to eight days, added two nights at Kia Ora, and would do the same again.
 
-<TrailSummary hike="overland-track" season="Oct–May" gearClass="Hut-to-hut · alpine, any season" map />
+<TrailSummary hike="overland-track" season="Jul (winter)" gearClass="Hut-to-hut · alpine, winter conditions" map />
 
 ## The route
 
-The Overland runs one way, south from Ronny Creek in the Cradle Valley to Narcissus Hut at the head of Lake St Clair, where most walkers take the ferry down the lake to Cynthia Bay. Between October and May a southbound booking and a Parks pass are compulsory, and a daily quota keeps the huts from overflowing. The shape of it is simple: a steep start onto the high plateau, a long traverse south down the spine of the park, and a final descent into rainforest and lakeshore.
+The track runs south through the heart of Cradle Mountain–Lake St Clair National Park, a slice of the Tasmanian Wilderness World Heritage Area. You start in the button-grass flats of Cradle Valley, climb onto the alpine plateau on the first morning, then spend the next week traversing south: across moorland and tarns, through myrtle-beech rainforest, over the exposed saddle of Pelion Gap, beneath the Du Cane Range, and finally down to Lake St Clair. In winter the shape of the country does not change, but the colour does — snow on the dolerite, ice on the boardwalks, and the track reduced to a thin line between white hills.
 
 <TrailMap hike="overland-track" />
 
 ## Day by day
 
-The six core stages below are the standard southbound itinerary. Distances are for the main track only — every side trip in the next section adds to the day. The numbers are forgiving: the longest day is the third, and even that is a gentle one once you are past the first morning's climb.
+These six stages are the spine of the route, but the numbers below reflect my winter timing — longer days, slower walking, and side trips folded in. If you are walking the standard summer itinerary you can compress days two and three, and skip the extra night at Kia Ora.
 
 <Stages accent="#5b8c5a">
 
-<Stage day={1} from="Ronny Creek" to="Waterfall Valley" distanceKm={10.7} ascentM={520} descentM={300} timeHours="4–6 h" terrain="Boardwalk over button grass, then a steep stepped climb to the plateau; exposed alpine moorland after.">
+<Stage day={1} from="Ronny Creek" to="Waterfall Valley" distanceKm={10.7} ascentM={520} descentM={300} timeHours="5–7 h" terrain="Boardwalk, icy rock, and the steep climb onto the Cradle plateau.">
 
-The hardest morning of the whole walk comes first. From the boardwalk at Ronny Creek the track climbs past Crater Lake and up the chained, stepped pitch to Marions Lookout, the highest point on the standard route. Get this behind you and the rest of the day — and arguably the rest of the track — is downhill by comparison.
+The shuttle from Launceston was meant to drop us at Ronny Creek around 6 am, but black ice had closed the road beyond the information centre. We walked the extra kilometre or so to the trailhead in the half-dark, boots crunching on frozen gravel. It was a rough start, but it also meant I met the group I would walk with for the rest of the trip: three friends and two of their sons, all of them faster and funnier than I had any right to hike with.
 
-<Checkpoint name="Marions Lookout" elevM={1250} kind="viewpoint" note="The high point of the standard route and the steepest climb on the track. Chains assist the final pitch above the tarns." />
+I had worried about deep Tasmanian winter snow — stories of walkers post-holing for days — but the cover was light and beautiful, more like a hard frost than an alpine blizzard. A little rain and snow fell in the first hour, then the sky cleared. We stopped at the Overland Track signpost for the obligatory photo, then climbed past Crater Lake and up the chained pitch to Marions Lookout.
 
-<Checkpoint name="Kitchen Hut" elevM={1230} kind="hut" note="A tiny emergency shelter on the Cradle plateau, and the junction for the Cradle Mountain summit side trip." />
+<TrailFigure
+  src="https://storage.googleapis.com/benebsworth-hiking/assets/1783245630066-img-7823.webp"
+  meta="Day 1 · Ronny Creek"
+  caption="The Overland Track signpost at Ronny Creek, with a dusting of fresh snow on the boardwalk."
+  width={2200}
+  height={1650}
+/>
 
-Beyond Kitchen Hut the track crosses the open Cradle plateau and begins its long descent into Waterfall Valley, tucked under the dark bulk of Barn Bluff. The valley is exposed and weather rolls through fast, so most walkers are glad of the hut.
+<Checkpoint name="Marions Lookout" elevM={1250} kind="viewpoint" note="The high point of the standard route. The chains are useful when the rock is iced." />
+<Checkpoint name="Kitchen Hut" elevM={1230} kind="hut" note="Emergency shelter and the turn-off for the Cradle Mountain summit side trip." />
 
-<Checkpoint name="Waterfall Valley Hut" elevM={1100} kind="hut" note="First night's hut, below Barn Bluff. The junction for the Barn Bluff side trip is passed on the way in." />
+Beyond Kitchen Hut the track crosses the open plateau and drops into Waterfall Valley. We arrived at the hut in the late afternoon, around 4 or 5 pm, with enough time to make a proper dinner and settle in before the temperature dropped. The hut was empty except for our group. I made coffee on the bench and watched the light fade off Barn Bluff.
 
-</Stage>
-
-<Stage day={2} from="Waterfall Valley" to="Lake Windermere" distanceKm={7.8} ascentM={150} descentM={250} timeHours="3–4 h" terrain="The easiest day — gentle moorland and boardwalk past alpine lakes and tarns.">
-
-A short, kind day. With the big climb behind you, the track ambles south across moorland strung with tarns, passing the junction to Lake Will — a worthwhile hour's detour to a quiet alpine lake under Barn Bluff. Lake Windermere itself is a good swimming lake on the rare warm afternoon.
-
-<Checkpoint name="Lake Will junction" kind="junction" note="A flat 3 km return side trip to an alpine lake; a popular lunch stop." />
-
-<Checkpoint name="Lake Windermere Hut" elevM={1000} kind="hut" note="The smallest hut on the track, sleeping 16. Book or camp accordingly." />
-
-</Stage>
-
-<Stage day={3} from="Lake Windermere" to="New Pelion" distanceKm={16.8} ascentM={300} descentM={420} timeHours="5–6 h" terrain="The longest day; long moorland traverse, then a descent through rainforest to the lowest point of the track and back up to Pelion Plains.">
-
-The longest stage, but not the hardest. The track runs south across moor and then drops steadily through myrtle-beech rainforest to Frog Flats, where it crosses the Forth River at the lowest point on the whole route. From there it climbs gently back to the open eucalypt of Pelion Plains, with the dolerite spires of Mount Oakleigh rising over the hut.
-
-<Checkpoint name="Frog Flats · Forth River" elevM={730} kind="water" note="The lowest point on the Overland, deep in damp myrtle rainforest." />
-
-<Checkpoint name="New Pelion Hut" elevM={860} kind="hut" note="The largest and arguably best-sited hut, sleeping 36, framed by the dolerite of Mount Oakleigh." />
+<TrailFigure
+  src="https://storage.googleapis.com/benebsworth-hiking/assets/1783245630056-img-7906.webp"
+  meta="Day 1 · Waterfall Valley Hut"
+  caption="A steaming drip coffee inside Waterfall Valley Hut — the small ritual that makes a cold hut feel like camp."
+  width={2200}
+  height={2933}
+/>
 
 </Stage>
 
-<Stage day={4} from="New Pelion" to="Kia Ora" distanceKm={8.6} ascentM={300} descentM={300} timeHours="3–4 h" terrain="A steady rainforest climb to the exposed alpine saddle of Pelion Gap, then down to Kia Ora.">
+<Stage day={2} from="Waterfall Valley" to="Lake Windermere" distanceKm={7.8} ascentM={150} descentM={250} timeHours="3–5 h" terrain="Gentle moorland, frozen boardwalk, and a short drop to the lake.">
 
-A short day on paper, but the day most walkers build their trip around — because Pelion Gap is the launch point for Tasmania's highest mountain. The track climbs through rainforest from Pelion Plains onto the bare saddle of Pelion Gap, where the junctions for Mount Ossa and Mount Pelion East break off. Even if you climb neither, the gap itself is a fine, wind-scoured place to stand.
+I slept better than expected and woke up feeling fresh. That lasted about ten minutes. The track out of Waterfall Valley was sheet ice in patches, and before I had properly woken up I slipped, landed hard on my knee, and spent the next few minutes sitting in the snow waiting for the pain to tell me how bad it was.
 
-<Checkpoint name="Pelion Gap" elevM={1140} kind="pass" note="The saddle between Mount Ossa and Mount Pelion East; junction for both summit side trips. Drop the heavy pack here." />
+It was bad enough that my first thought was the Garmin inReach Mini 2 in my pack and whether this was the helicopter moment. After a rest, a check of the joint, and some very careful walking, it seemed stable. I decided to push on slowly. The knee swelled over the next two days, but it held. I was lucky: the fall missed my patella and did no real structural damage.
 
-<Checkpoint name="Kia Ora Hut" elevM={1000} kind="hut" note="Fourth night's hut, set above Kia Ora Creek." />
+<TrailFigure
+  src="https://storage.googleapis.com/benebsworth-hiking/assets/1783245630045-img-7983.webp"
+  meta="Day 2 · Lake Windermere"
+  caption="The bruised shin that made me consider pressing the SOS button on my first real day."
+  width={2200}
+  height={2933}
+/>
 
-</Stage>
+We stopped for lunch beside a half-frozen lake with Barn Bluff rising behind it, then continued on to Lake Windermere Hut. That afternoon, with the knee throbbing and the day still clear, I waded into the lake. It was July in Tasmania, so "swim" is a generous word — more of a gasp, a float, and a rapid exit. But the cold took the swelling down better than anything in my first-aid kit, and the reset was worth the shock.
 
-<Stage day={5} from="Kia Ora" to="Bert Nichols (Windy Ridge)" distanceKm={9.6} ascentM={300} descentM={350} timeHours="4–5 h" terrain="Rainforest beneath the Du Cane Range, past a cluster of waterfall side trips, over Du Cane Gap and down to Windy Ridge.">
-
-The waterfall day. From Kia Ora the track threads beneath the towers of the Du Cane Range, passing the historic Du Cane Hut and a string of short side trips to D'Alton, Fergusson and Hartnett Falls — at their thundering best after rain. It then climbs to Du Cane Gap before dropping to Bert Nichols Hut at the head of the Narcissus valley.
-
-<Checkpoint name="Du Cane Hut" kind="hut" note="A timber hut built in 1910; a fine lunch spot, but an emergency shelter only — not for overnight use." />
-
-<Checkpoint name="Waterfall junctions" kind="junction" note="Short detours to D'Alton, Fergusson and Hartnett Falls, all best after rain." />
-
-<Checkpoint name="Du Cane Gap" elevM={1070} kind="pass" note="The high point of the day, beneath Mount Geryon and the Acropolis." />
-
-<Checkpoint name="Bert Nichols Hut" elevM={950} kind="hut" note="Also called Windy Ridge; the last hut on the core track, with the Du Cane Range behind it." />
+<Checkpoint name="Lake Will junction" kind="junction" note="A flat 3 km return side trip; worth it in good weather." />
+<Checkpoint name="Lake Windermere Hut" elevM={1000} kind="hut" note="The smallest hut on the track. In winter it feels like a refuge." />
 
 </Stage>
 
-<Stage day={6} from="Bert Nichols" to="Narcissus · Lake St Clair" distanceKm={9.0} ascentM={120} descentM={330} timeHours="3 h" terrain="A gentle, mostly downhill walk through forest to the lakeshore.">
+<Stage day={3} from="Lake Windermere" to="New Pelion" distanceKm={16.8} ascentM={300} descentM={420} timeHours="5–7 h" terrain="Long moorland traverse, then rainforest down to Frog Flats and back up to Pelion Plains.">
 
-The last morning is an easy, mostly downhill walk through forest to Narcissus Hut on the northern shore of Lake St Clair. Radio ahead to confirm the ferry from the hut, which carries most walkers down Australia's deepest lake to Cynthia Bay and the end of the track. Those with time and energy can instead walk the lakeshore the full 17.5 km to Cynthia Bay.
+I gave myself a rest morning at Windermere. The lake was perfectly still at dawn, and Barn Bluff was reflected in the dark water with a clarity that made the early start feel easy. I took more photos than I needed, then packed up and left with the group in mid-morning.
 
-<Checkpoint name="Pine Valley junction" kind="junction" note="5 km before Narcissus; the turn-off for the Pine Valley, Acropolis and Labyrinth side trips." />
+<TrailFigure
+  src="https://storage.googleapis.com/benebsworth-hiking/assets/1783245630048-img-7972.webp"
+  meta="Day 3 · Lake Windermere"
+  caption="Lake Windermere reflecting Barn Bluff on a still winter morning."
+  width={2200}
+  height={2933}
+/>
 
-<Checkpoint name="Narcissus Hut · Lake St Clair" elevM={740} kind="milestone" note="The end of the core track. Radio to confirm the ferry, or walk the lakeshore to Cynthia Bay." />
+The longest day of the standard route, but not the hardest. The track runs south across open moor, drops through myrtle-beech rainforest to Frog Flats — the lowest point on the whole walk — and then climbs gently back to Pelion Plains. Mount Oakleigh's dolerite organ pipes come into view long before you reach the hut, and they dominated the evening light.
+
+<Checkpoint name="Frog Flats · Forth River" elevM={730} kind="water" note="The lowest point on the Overland, damp and sheltered even in winter." />
+<Checkpoint name="New Pelion Hut" elevM={860} kind="hut" note="The largest hut on the track, framed by Mount Oakleigh." />
+
+</Stage>
+
+<Stage day={4} from="New Pelion" to="Kia Ora" distanceKm={8.6} ascentM={300} descentM={300} timeHours="4–6 h" terrain="Rainforest climb to Pelion Gap, then down to Kia Ora.">
+
+This was the day I built the trip around. I left New Pelion before dawn to climb Mount Oakleigh for sunrise, reaching the summit while the light was still thin and pink. There was enough phone reception at the top for one brief call, and I used it to call my then-girlfriend — now wife — Jess. It felt like a small miracle, a private conversation from the top of a mountain in the middle of Tasmania.
+
+By the time I got back to the hut the group was ready to move. We packed up, climbed through rainforest to Pelion Gap, and dropped down to Kia Ora Hut in the early afternoon. The gap itself is a wind-scoured saddle between Mount Ossa and Mount Pelion East, and the junction signposts point off in three directions: up, up, and down.
+
+<Checkpoint name="Mount Oakleigh" elevM={1280} kind="summit" note="Best at sunrise. The view north over Pelion Plains is worth the early start." />
+<Checkpoint name="Pelion Gap" elevM={1140} kind="pass" note="The saddle between Mount Ossa and Mount Pelion East. Leave the big pack here for side trips." />
+<Checkpoint name="Kia Ora Hut" elevM={1000} kind="hut" note="Base for the Du Cane waterfalls and the side-quest day." />
+
+</Stage>
+
+<Stage day={5} from="Kia Ora" to="Bert Nichols (Windy Ridge)" distanceKm={9.6} ascentM={300} descentM={350} timeHours="4–5 h" terrain="Waterfall side trips, Du Cane Gap, and descent to Windy Ridge.">
+
+It was my birthday, and I did not remember until I got back to the hut. I spent the morning on a double side-quest: Mount Ossa first, then Mount Pelion East, returning to Kia Ora for lunch and a rest before pushing on. That is only possible if you are staying at Kia Ora a second night, which I was — it made the day feel generous rather than rushed.
+
+Mount Ossa is the reason many people walk the Overland. It is Tasmania's highest summit at 1,617 metres, and on a clear day the view takes in most of the park's named peaks. The route from Pelion Gap climbs through a scree gully and finishes on exposed boulders; under snow the rock is slick, and the drop on either side is real. Mount Pelion East is shorter and quieter, a good second summit if the legs are willing.
+
+After lunch we packed up and walked the waterfall section of the main track: past Du Cane Hut and the short detours to D'Alton, Fergusson and Hartnett Falls, then over Du Cane Gap and down to Bert Nichols Hut. The falls were running hard after winter rain, and the forest was thick with mist.
+
+<Checkpoint name="Du Cane Hut" kind="hut" note="A 1910 timber hut; lunch spot only, not for overnight." />
+<Checkpoint name="Waterfall junctions" kind="junction" note="Short detours to D'Alton, Fergusson and Hartnett Falls." />
+<Checkpoint name="Du Cane Gap" elevM={1070} kind="pass" note="Beneath Mount Geryon and the Acropolis." />
+<Checkpoint name="Bert Nichols Hut" elevM={950} kind="hut" note="Also called Windy Ridge; the last hut on the core track." />
+
+</Stage>
+
+<Stage day={6} from="Bert Nichols" to="Narcissus · Lake St Clair" distanceKm={9.0} ascentM={120} descentM={330} timeHours="3 h" terrain="Mostly downhill forest walk to the lake shore.">
+
+The last morning was easy walking through forest to Narcissus Hut. I had planned to walk the full lakeshore track to Cynthia Bay, but the group was taking the ferry and I decided to join them. The lakeshore route is reputedly muddy and less well maintained, and after eight days — and a bruised knee — the ferry was the smarter finish. It also gave us time to make the shuttle back to Launceston and find a proper meal.
+
+<Checkpoint name="Pine Valley junction" kind="junction" note="Turn-off for the Pine Valley, Acropolis and Labyrinth side trips." />
+<Checkpoint name="Narcissus Hut · Lake St Clair" elevM={740} kind="milestone" note="The end of the core track. Radio to confirm the ferry." />
+
+We landed back in Launceston in the early evening, dirty and tired, and went straight to a restaurant for the kind of meal that only tastes that good at the end of a long walk. I cannot remember what I ordered; I remember the relief.
+
+<TrailFigure
+  src="https://storage.googleapis.com/benebsworth-hiking/assets/1783245630074-img-8480.webp"
+  meta="Day 8 · Launceston"
+  caption="The first drink back in Launceston, at the end of eight days on the track."
+  width={2200}
+  height={2933}
+/>
 
 </Stage>
 
@@ -101,205 +148,175 @@ The last morning is an easy, mostly downhill walk through forest to Narcissus Hu
 
 ## Side trips
 
-The walkers who get the most out of the Overland are the ones who treat the huts as a baseline and the summits as the point. Each of these leaves from a junction on the main track; carry water, weather gear and a light day load, and leave the big pack at the junction. None should be attempted in cloud, high wind or snow — the upper sections are exposed boulder scrambles where a whiteout is genuinely dangerous.
+The main track is the skeleton; the side trips are the reason you carry a light day pack. In winter they take longer and demand better weather, but the emptiness of the huts means you can schedule rest days around them.
 
-<Quest accent="#5b8c5a" title="Mount Ossa — the roof of Tasmania" extraKm={5.2} extraAscentM={500} extraTimeHours={5} difficultyDelta="harder" payoff="The highest point in Tasmania, with the whole park laid out beneath you on a clear day — and a summit most of the walk's photographs are taken from.">
+<Quest accent="#5b8c5a" title="Mount Ossa — the roof of Tasmania" extraKm={5.2} extraAscentM={500} extraTimeHours={5} difficultyDelta="harder" payoff="The highest point in Tasmania, with the whole park laid out beneath you on a clear day.">
 
-The classic detour, leaving from Pelion Gap on day four. The route contours around Mount Doris to a saddle with fine views, then climbs steeply through a scree gully and over boulders to the summit at 1,617 metres. Allow four to five hours of daylight to summit and return to the gap, plus the hour down to Kia Ora. Save it for a clear, settled day — the boulder field is treacherous under snow.
-
+Leaves from Pelion Gap on the climb up from New Pelion. The route contours around Mount Doris, then climbs a scree gully and finishes on exposed boulders. Under snow the boulders are treacherous — save it for a settled, clear day. I combined it with Mount Pelion East in a single long birthday morning, but most walkers should allow a full day.
 </Quest>
 
-<Quest accent="#5b8c5a" title="Barn Bluff" extraKm={7.0} extraAscentM={450} extraTimeHours={4} difficultyDelta="harder" payoff="A 360° view back over the Cradle plateau you have just crossed, from one of the most photogenic peaks in the park.">
+<Quest accent="#5b8c5a" title="Mount Pelion East" extraKm={3.6} extraAscentM={300} extraTimeHours={3} difficultyDelta="harder" payoff="A quieter summit right beside Ossa, with similar views and far fewer people.">
 
-The dark, blunt peak that dominates the first two days. The side trip leaves from near the day-one junction below Waterfall Valley, climbing steeply with some boulder scrambling to the 1,559-metre summit. Fine weather only — the upper mountain is exposed and the scramble is no place to be in cloud.
-
+Also from Pelion Gap. The route is shorter and less committing than Ossa, which makes it a good second summit if you have the legs and the weather. I tagged it after Ossa on the same morning and was back at Kia Ora for lunch.
 </Quest>
 
-<Quest accent="#5b8c5a" title="Pine Valley & the Acropolis" extraKm={9.4} extraAscentM={600} extraTimeHours="2 days" difficultyDelta="much-harder" payoff="The most spectacular rock scenery on the whole trip — the spires of the Acropolis and the tarn-strewn maze of the Labyrinth, well off the main line.">
+<Quest accent="#5b8c5a" title="Mount Oakleigh — sunrise summit" extraKm={4.0} extraAscentM={420} extraTimeHours={4} difficultyDelta="harder" payoff="The best sunrise on the track, looking north over Pelion Plains toward Cradle Mountain.">
 
-The longest detour, and best done as an extra night rather than a rushed day. The track to Pine Valley Hut leaves the main line about 5 km short of Narcissus; from the hut, the Acropolis is a serious all-day scramble up to 1,471 metres, and the Labyrinth a gentler wander through a plateau of tarns. Carry overnight gear and a route-finding head — this is the wildest country the trip touches.
+A pre-dawn climb from New Pelion Hut. The summit is lower than Ossa but the morning light on the dolerite pipes and the view back toward the plateau make it feel like the best-kept secret of the walk. There was enough reception at the top for a phone call, which is not something I expected in the Tasmanian wilderness.
+</Quest>
 
+<Quest accent="#5b8c5a" title="Barn Bluff" extraKm={7.0} extraAscentM={450} extraTimeHours={4} difficultyDelta="harder" payoff="A 360° view back over the Cradle plateau from one of the park's most photogenic peaks.">
+
+The dark peak that dominates the first two days. The side trip leaves from near Waterfall Valley Hut and involves some boulder scrambling near the top. In winter the upper mountain holds snow and the rock is slick; fine weather only.
+</Quest>
+
+<Quest accent="#5b8c5a" title="Pine Valley & the Acropolis" extraKm={9.4} extraAscentM={600} extraTimeHours="2 days" difficultyDelta="much-harder" payoff="The wildest rock scenery on the trip — the Acropolis and the Labyrinth.">
+
+Best done as an extra night rather than a day trip. The turn-off is about 5 km before Narcissus. I skipped it this time, but it is the obvious reason to come back.
 </Quest>
 
 ## Where you sleep
 
-The core track has a hut at the end of each of the first five days, with platforms for tents alongside. The huts are unstaffed and unbookable individually — you book the track, not the bed — so they run first-come, and on a busy night the overflow tents on the platforms. Carry a stove and full sleeping kit regardless; the huts have no mattresses, no power and no guaranteed space.
+The huts are unstaffed, unheated, and run on a first-come basis within your track booking. In winter they are rarely full, but the cold is the real constraint — carry a four-season bag, a full sleeping kit, and a stove regardless of whether you plan to tent. The platforms outside are for overflow in summer; in winter you want to be inside.
 
 <TrailGrid cols={2} accent="#5b8c5a">
 
-<Stop name="Waterfall Valley Hut" type="hut" elevM={1100} capacity={34} water booking="Track booking via Parks Tasmania (Oct–May)" note="Night one, below Barn Bluff. Exposed valley — weather moves through fast." />
+<Stop name="Waterfall Valley Hut" type="hut" elevM={1100} capacity={34} water booking="Track booking via Parks Tasmania" note="Night one, below Barn Bluff. Cold, exposed, and a good place to get dinner sorted early." />
 
-<Stop name="Lake Windermere Hut" type="hut" elevM={1000} capacity={16} water booking="Track booking via Parks Tasmania (Oct–May)" note="The smallest hut on the track; expect overflow to tents on a busy night." />
+<Stop name="Lake Windermere Hut" type="hut" elevM={1000} capacity={16} water booking="Track booking via Parks Tasmania" note="The smallest hut; a beautiful place to take a rest day in winter." />
 
-<Stop name="New Pelion Hut" type="hut" elevM={860} capacity={36} water booking="Track booking via Parks Tasmania (Oct–May)" note="The largest and best-sited hut, under the dolerite of Mount Oakleigh." />
+<Stop name="New Pelion Hut" type="hut" elevM={860} capacity={36} water booking="Track booking via Parks Tasmania" note="The largest and best-sited hut, under Mount Oakleigh." />
 
-<Stop name="Kia Ora Hut" type="hut" elevM={1000} capacity={34} water booking="Track booking via Parks Tasmania (Oct–May)" note="Night four, above Kia Ora Creek; the staging point for the day of waterfalls." />
+<Stop name="Kia Ora Hut" type="hut" elevM={1000} capacity={34} water booking="Track booking via Parks Tasmania" note="Stay two nights if you want to climb Ossa and Pelion East without a heavy pack." />
 
-<Stop name="Bert Nichols Hut (Windy Ridge)" type="hut" elevM={950} capacity={24} water booking="Track booking via Parks Tasmania (Oct–May)" note="The newest and last hut on the core track, with a large enclosed dining area." />
+<Stop name="Bert Nichols Hut (Windy Ridge)" type="hut" elevM={950} capacity={24} water booking="Track booking via Parks Tasmania" note="The last hut on the core track, with a large enclosed dining area." />
 
-<Stop name="Narcissus Hut" type="hut" elevM={740} water booking="No overnight booking — radio to confirm the ferry" note="A day-use and emergency hut at the lake; most walkers ferry on from here rather than stay." />
+<Stop name="Narcissus Hut" type="hut" elevM={740} water booking="No overnight booking — radio to confirm the ferry" note="A day-use and emergency hut at the lake." />
 
 </TrailGrid>
 
 ## Landmarks
 
-A handful of features anchor the walk, and you measure your progress against them — the peak that watches over the first days, the lake that ends it, the dolerite that frames the middle.
-
 <TrailGrid cols={2} accent="#5b8c5a">
 
 <Landmark name="Cradle Mountain" kind="summit" elevM={1545} bearing="N from the start">
-
-The serrated dolerite skyline that gives the park its name and the track its opening image. The summit itself is an optional scramble from Kitchen Hut on day one — a stiff couple of hours of boulder hopping for a view over the whole northern end of the park.
-
+The serrated skyline that gives the park its name. The summit scramble from Kitchen Hut is harder under snow; many winter walkers skip it.
 </Landmark>
 
 <Landmark name="Barn Bluff" kind="summit" elevM={1559} bearing="S of Cradle">
-
-The blunt, dark cone that dominates the first two days. Lower than Cradle but more isolated, it is one of the most recognisable peaks in the park and a popular early side trip.
-
+The blunt cone that dominates the first two days. Photogenic from almost every angle, especially reflected in the lakes near Waterfall Valley and Windermere.
 </Landmark>
 
 <Landmark name="Mount Ossa" kind="summit" elevM={1617} bearing="W of Pelion Gap">
-
-Tasmania's highest mountain, and the high point of the whole walk if you climb it. A steep scramble from Pelion Gap delivers a summit panorama over most of the park's named peaks.
-
+Tasmania's highest mountain and the high point of the walk. A clear-day scramble from Pelion Gap.
 </Landmark>
 
 <Landmark name="Mount Oakleigh" kind="summit" elevM={1280} bearing="N over Pelion">
-
-The wall of dolerite organ-pipes that frames the view north from New Pelion Hut — one of the most photographed outlooks on the track, especially at sunset.
-
+The dolerite wall above New Pelion Hut. The sunrise summit is one of the best on the track.
 </Landmark>
 
-<Landmark name="The Acropolis" kind="summit" elevM={1471} bearing="E of Du Cane Gap">
-
-The great rampart of the Du Cane Range, reached only via the Pine Valley side trip. Its spires look unclimbable but yield a scrambler's route to the top.
-
+<Landmark name="Lake Windermere" kind="lake" bearing="Day 2">
+A small alpine lake that freezes at the edges in winter. The reflections of Barn Bluff at dawn are worth a rest day.
 </Landmark>
 
 <Landmark name="Lake St Clair" kind="lake" elevM={737} bearing="S terminus">
-
-The deepest natural lake in Australia, carved by glaciers, and the end of the line. The ferry down the lake from Narcissus is the traditional finish to the walk.
-
+The deepest natural lake in Australia. The ferry from Narcissus is the traditional finish.
 </Landmark>
 
 </TrailGrid>
 
 ## What grows here
 
-This is Gondwanan country — the plants here trace back to a supercontinent, and many grow nowhere else on Earth. Between two-fifths and over half of the park's alpine flora is endemic to Tasmania, much of it ancient, slow-growing and intolerant of fire. Tread the boardwalk and stay off the cushion plants; some of what you are walking past has been growing since before the printing press.
+This is Gondwanan country, and in winter it strips down to its structure: snow on the dolerite, dark green myrtle-beech in the gullies, and the pale trunks of pencil pines against the white hills.
 
 <TrailGrid cols={3} accent="#5b8c5a">
 
 <Flora name="Pandani" latin="Richea pandanifolia" when="Year-round" where="Crater Lake, rainforest edges">
-
-The tallest heath plant in the world, and unmistakable: a shaggy palm-like crown of long spined leaves on a single trunk. It looks tropical and is anything but — a hardy Tasmanian alpine endemic, thickest around Crater Lake on the first morning.
-
+The tallest heath plant in the world, a shaggy palm-like crown of strappy leaves that looks tropical and is anything but.
 </Flora>
 
 <Flora name="Deciduous beech (fagus)" latin="Nothofagus gunnii" when="Colour in late April" where="Alpine slopes, tarn shelves">
-
-Australia's only winter-deciduous native tree, and a Tasmanian endemic. For most of the year it is an unremarkable low scrub, but in late April its crinkled leaves turn gold and rust in a brief blaze the locals simply call "the turning of the fagus".
-
+Australia's only winter-deciduous native tree. In late April its leaves turn gold and rust in "the turning of the fagus".
 </Flora>
 
 <Flora name="King Billy pine" latin="Athrotaxis selaginoides" when="Year-round" where="Sheltered rainforest gullies">
+A Gondwanan conifer; some standing on the track are more than a thousand years old.
+</Flora>
 
-A Gondwanan conifer, cousin to the Californian redwoods, with soft russet bark and a slow, slow growth. Some standing on the track are more than a thousand years old; a fire that kills them is a loss measured in millennia.
-
+<Flora name="Pencil pine" latin="Athrotaxis cupressoides" when="Year-round" where="Alpine lake edges">
+Pale-barked and slow-growing, often the only tree around the frozen tarns of the central plateau.
 </Flora>
 
 <Flora name="Button grass" latin="Gymnoschoenus sphaerocephalus" when="Year-round" where="Open moorland plains">
-
-The tussocky sedge that defines the open moorland, named for the round seed-heads bobbing on long stems. It carpets the plains between the high points and gives the lower track its characteristic tea-coloured, peaty ground.
-
-</Flora>
-
-<Flora name="Cushion plants" latin="Abrotanella, Donatia spp." when="Year-round" where="Exposed alpine flats">
-
-Tight green mounds that look like moss but are dense colonies of tiny flowering plants, packed hard against the alpine wind. They grow agonisingly slowly and a single bootprint can scar them for years — which is why the boardwalk exists.
-
+The tussocky sedge that carpets the plains between the high points.
 </Flora>
 
 <Flora name="Myrtle beech" latin="Nothofagus cunninghamii" when="Year-round" where="Temperate rainforest">
-
-The backbone of the cool temperate rainforest the track drops into at Frog Flats and below the Du Cane Range — dark, small-leaved canopy over a deep moss understorey, another survivor of the Gondwanan flora.
-
+The backbone of the cool temperate rainforest below Frog Flats and the Du Cane Range.
 </Flora>
 
 </TrailGrid>
 
 ## What lives here
 
-The animals are mostly nocturnal and most reliably seen at dusk around the huts and at the Ronny Creek boardwalk at either end of the day. Keep food sealed and packs closed — the black currawongs in particular are practised thieves — and watch where you put your hands and feet in the warmer months, when tiger snakes are about.
+Most animals keep a low profile in winter, but the huts still attract black currawongs, and wombat tracks crisscross the snow around Ronny Creek at dawn.
 
 <TrailGrid cols={3} accent="#5b8c5a">
 
 <Fauna name="Common wombat" latin="Vombatus ursinus" likelihood="common" where="Ronny Creek, trailsides at dusk">
-
-The most reliable large sighting on the track. Wombats graze the button-grass flats around Ronny Creek at dawn and dusk, unbothered by walkers; give them room and they will keep cropping grass beside the boardwalk.
-
+The most reliable large sighting. Give them room and they will keep cropping grass beside the boardwalk.
 </Fauna>
 
 <Fauna name="Bennett's wallaby" latin="Notamacropus rufogriseus" likelihood="common" where="Open moorland, around huts">
-
-The larger of the two common macropods, often around the huts at dusk. Told from the pademelon by its longer legs and tail, rufous neck and the dark stripe down its face.
-
+Often around the huts at dusk, with a rufous neck and dark face stripe.
 </Fauna>
 
 <Fauna name="Tasmanian pademelon" latin="Thylogale billardierii" likelihood="common" where="Forest edges, hut clearings">
-
-A small, round, short-tailed wallaby of the forest understorey, and one of the most-seen animals around camp after dark. Endemic to Tasmania and the islands of Bass Strait.
-
+A small, round, short-tailed wallaby endemic to Tasmania.
 </Fauna>
 
 <Fauna name="Short-beaked echidna" latin="Tachyglossus aculeatus" likelihood="occasional" where="Open woodland and moorland">
-
-A spiny, ant-eating monotreme that potters across the track in daylight, snout down. Unhurried and unbothered; if disturbed it simply digs in or rolls into a spined ball.
-
+A spiny monotreme often seen pottering across the track in daylight.
 </Fauna>
 
 <Fauna name="Black currawong" latin="Strepera fuliginosa" likelihood="common" where="Huts and campsites">
-
-A large, glossy-black, yellow-eyed bird endemic to Tasmania, and the resident opportunist at every hut. Bold and clever — it will work zips and open lids, so hang or seal anything edible.
-
+A large, glossy-black, yellow-eyed bird endemic to Tasmania. It will open zips and lids — seal your food.
 </Fauna>
 
 <Fauna name="Tasmanian devil" latin="Sarcophilus harrisii" likelihood="rare" where="Nocturnal, forested sections">
-
-The island's marsupial carnivore — stocky, black, and far more often heard than seen. A sighting is a rare privilege; most walkers know it only by the screeching from the dark and the tracks at the hut edge.
-
+More often heard than seen. A sighting is a rare privilege.
 </Fauna>
 
 </TrailGrid>
 
 ## Gear
 
-The single rule that shapes the kit list: it can snow on the Overland in any month, and the weather can turn from sun to sleet in under an hour. Pack for winter even in midsummer. Beyond the four-season layers, you carry your own shelter and stove regardless of the huts, because a full hut on a bad night means a tent on a platform.
+Winter changes the kit list. Snow, ice and sub-zero hut nights are the baseline, not the exception. The four-season sleeping bag is non-negotiable, and so is the ability to make hot food and drinks in a hut with no cooking facilities.
 
 <GearList accent="#5b8c5a">
 
-<Gear name="Waterproof hiking boots" group="worn" essential note="Worn in well before the trip; the track is wet, rooty and rocky." />
-<Gear name="Gaiters" group="worn" note="The button-grass and mud sections soak low legs and socks fast." />
-<Gear name="Merino base layers" group="worn" essential note="Wool over cotton — it keeps warming when wet." />
-
+<Gear name="Meindl Guffert boots" group="worn" essential note="Stiff, waterproof, and grippy on iced rock and frozen boardwalks. Worn in before the trip." />
+<Gear name="Gaiters" group="worn" essential note="Keep snow and mud out of your boots on the moorland sections." />
+<Gear name="Merino base layers" group="worn" essential note="Wool keeps warming when wet." />
+<Gear name="Microspikes or light crampons" group="worn" essential note="Black ice on the boardwalks and rock pitches is real." />
 <Gear name="Four-season sleeping bag" group="pack" essential note="Rated for sub-zero; the huts are unheated and have no mattresses." />
-<Gear name="Lightweight tent" group="pack" essential note="The huts can fill — a tent for the platform is non-negotiable, not optional." />
+<Gear name="Lightweight tent" group="pack" essential note="The huts can fill — a tent for the platform is non-negotiable." />
 <Gear name="Stove, fuel and pot" group="pack" essential note="No cooking facilities or fires; all meals are self-cooked." />
 <Gear name="Sleeping mat" group="pack" essential note="Insulation as much as comfort — the hut platforms are bare timber." />
-<Gear name="Full waterproof shell — jacket and overtrousers" group="pack" essential note="Not a rain jacket of convenience; genuine alpine wet-weather kit." />
+<Gear name="Full waterproof shell" group="pack" essential note="Jacket and overtrousers. Genuine alpine wet-weather kit, not a city rain jacket." />
 <Gear name="Warm insulated layer" group="pack" essential note="Down or synthetic puffy for the huts and exposed gaps." />
-<Gear name="Five to six days of food" group="pack" essential note="No resupply on the track; carry it all from Cradle Valley." />
+<Gear name="Five to eight days of food" group="pack" essential note="No resupply; carry it all from Cradle Valley. Add extra for rest and side-trip days." />
 
-<Gear name="Personal locator beacon (PLB)" group="safety" essential note="Mobile coverage is effectively nil; a beacon is your only call for help." />
+<Gear name="Garmin inReach Mini 2" group="safety" essential note="Mobile coverage is effectively nil; this is your SOS and messaging link." />
+<Gear name="Personal locator beacon (PLB)" group="safety" note="A backup to the inReach, or a lighter alternative if you do not need two-way messaging." />
 <Gear name="Map and compass" group="safety" essential note="Whiteouts are common on the high gaps; do not rely on a phone alone." />
-<Gear name="First-aid kit and snake-bite bandages" group="safety" essential note="Tiger snakes are present in the warmer months; carry compression bandages." />
-<Gear name="Headtorch and spare batteries" group="safety" essential note="For the wildlife at dusk and the early starts as much as emergencies." />
+<Gear name="First-aid kit" group="safety" essential note="Include compression bandages, pain relief, and a knee brace if you have any history." />
+<Gear name="Headtorch and spare batteries" group="safety" essential note="Short winter days mean early starts and late finishes in the dark." />
 
-<Gear name="Lightweight day pack or pack liner" group="optional" note="For side trips — carry light and leave the main pack at the junction." />
-<Gear name="Trekking poles" group="optional" note="Useful on the day-one descent and the boulder approaches to the summits." />
-<Gear name="Swimming kit" group="optional" note="For Lake Windermere and the tarns on a rare warm afternoon." />
+<Gear name="Trekking poles" group="optional" note="Useful on ice, on descents, and for a swollen knee." />
+<Gear name="Swimming kit" group="optional" note="For Lake Windermere. Brief, cold, and surprisingly therapeutic." />
+<Gear name="Camera with spare batteries" group="optional" note="Cold drains batteries fast; keep a spare warm in your sleeping bag." />
 
 </GearList>
 
-The Overland rewards the walker who comes prepared for worse weather than they get, and who carries light enough to say yes to the side trips. Book early, watch the forecast, climb Ossa on the clear day, and let the rain days be the ones you spend in the rainforest among the thousand-year-old pines. That is the trip people come back from changed.
+The Overland in winter is not the same walk as the Overland in summer. It is slower, colder, and emptier. The side trips take longer, the days end earlier, and a slip on ice can turn a good morning into a serious decision. But the huts are quiet, the snow turns the plateau into something elemental, and the moments that matter — a sunrise on Mount Oakleigh, a frozen lake reflecting Barn Bluff, a phone call from a summit, a birthday spent climbing two mountains — feel earned in a way that fair-weather walking rarely does. Pack for the cold, give yourself the extra days, and say yes to the detours.

--- a/content/hiking.ts
+++ b/content/hiking.ts
@@ -316,7 +316,10 @@ export const getHike = (slug: string) => hikes.find((h) => h.slug === slug)
  * both directions. The Overland guide exists but is kept unpublished, so it is
  * intentionally absent here. Add an entry when a new guide goes live.
  */
-export const HIKE_GUIDE: Record<string, string> = { 'haute-route': 'haute-route-guide' }
+export const HIKE_GUIDE: Record<string, string> = {
+  'haute-route': 'haute-route-guide',
+  'overland-track': 'overland-track-guide',
+}
 export const guideForHike = (hikeSlug: string): string | undefined => HIKE_GUIDE[hikeSlug]
 export const hikeForGuide = (guideSlug: string): string | undefined =>
   Object.keys(HIKE_GUIDE).find((h) => HIKE_GUIDE[h] === guideSlug)

--- a/docs/hiking-admin-setup.md
+++ b/docs/hiking-admin-setup.md
@@ -1,10 +1,10 @@
 # Hiking admin — GCS + Google sign-in
 
-The hiking gallery editor is **backend-free**: signing in with Google on a hiking
-page yields an OAuth access token with the GCS read/write scope, and the browser
-uploads photos **directly** to the bucket. Security is the bucket's IAM (only the
-admin's account can write) + CORS — not the client-side email check (that only
-decides whether the editor UI renders).
+The image admin CRM is **backend-free**: signing in with Google on a hiking page
+(or any page with the admin gate) yields an OAuth access token with the GCS
+read/write scope, and the browser uploads photos **directly** to the bucket.
+Security is the bucket's IAM (only the admin's account can write) + CORS — not
+the client-side email check (that only decides whether the editor UI renders).
 
 ## Status — provisioned 2026-06-26 (Terraform)
 
@@ -46,16 +46,22 @@ this one step is manual (~3 min). In **console.cloud.google.com** with project
 
 Then on a hiking page: discreet **◐ admin** (bottom-right) → sign in → the inline
 **editor** appears on each hike. Add photos (auto-resized to webp, uploaded to
-`gs://benebsworth-hiking/hiking/<slug>/`), caption, assign waypoints, reorder,
-**Save** (writes `manifest.json`). Galleries read the manifest live — no redeploy.
+`gs://benebsworth-hiking/assets/hike/<slug>/`), caption, assign waypoints, reorder,
+**Save** (writes `manifest/hike/<slug>.json`). Galleries read the manifest live — no redeploy.
+
+Photos are namespaced by the item you upload from (`assets/<type>/<slug>/`), and
+tagged with `itemType`/`itemSlug` in the global `library/index.json`. That lets
+the `tools/hike-annotate` pipeline classify every photo for a hike without
+guessing which library assets belong to it.
 
 Dev-only: append `?previewAdmin=1` to preview the editor UI without real OAuth.
 
 ## Code map
 
-- `lib/hiking/config.ts` — public config (admin email is static here).
-- `components/hiking/admin/admin-context.tsx` — GIS token client (email + GCS scope).
-- `lib/hiking/gcs.ts` — browser resize→webp + direct GCS upload + manifest write.
-- `components/hiking/admin/gallery-editor.tsx` — the editor UI (admin-only).
+- `lib/admin/config.ts` — public config (admin email is static here).
+- `components/admin/admin-context.tsx` — GIS token client (email + GCS scope).
+- `lib/admin/gcs.ts` — browser resize→webp + direct GCS upload + manifest/library write.
+- `lib/admin/storage.ts` — GCS object layout (`assets/<type>/<slug>/`, `manifest/<type>/<slug>.json`, `library/index.json`).
+- `components/admin/admin-shell.tsx` — the editor UI (admin-only).
 - `components/hiking/hike-journey.tsx` — reads the live manifest; map + gallery + (admin) editor.
 - `infra/gcp/` — the bucket, IAM, and CORS as Terraform.

--- a/e2e/overland-track-guide.spec.ts
+++ b/e2e/overland-track-guide.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test'
+
+test('published Overland Track winter guide renders and links to the hike overview', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (error) => errors.push(String(error)))
+
+  await page.goto('/blog/overland-track-guide/')
+
+  await expect(page.getByRole('heading', { name: 'The Overland Track in winter — a trail guide' })).toBeVisible()
+  await expect(page.getByText('The Overland Track is usually a six-day summer walk')).toBeVisible()
+  await expect(page.getByText('The shuttle from Launceston was meant to drop us at Ronny Creek')).toBeVisible()
+  await expect(page.getByText('Night one, below Barn Bluff. Cold, exposed, and a good place to get dinner sorted early.')).toBeVisible()
+  await expect(page.getByRole('link', { name: /Overland Track — map, stats & gallery/i })).toHaveAttribute(
+    'href',
+    '/hiking/overland-track/',
+  )
+
+  await page.getByRole('button', { name: /Lake Windermere, 1,000 metres, Day 2/i }).first().click()
+  await expect(page.getByRole('link', { name: /Day 2/i })).toHaveAttribute('href', '#day-2')
+
+  await page.getByRole('link', { name: /Overland Track — map, stats & gallery/i }).click()
+  await expect(page).toHaveURL(/\/hiking\/overland-track\/$/)
+  await expect(page.getByRole('heading', { name: 'Overland Track' })).toBeVisible()
+  await expect(page.getByRole('link', { name: /Read the trail guide/i })).toHaveAttribute(
+    'href',
+    '/blog/overland-track-guide/',
+  )
+
+  expect(errors).toEqual([])
+})

--- a/lib/admin/gcs.ts
+++ b/lib/admin/gcs.ts
@@ -124,10 +124,16 @@ async function readGeo(file: File): Promise<{ lat: number; lng: number; takenAt:
   return { lat, lng, takenAt }
 }
 
-/** Upload one image to the shared pool as a full + thumbnail webp; returns its
- *  Asset (with EXIF geo). Both variants are immutable-cached; grids use the
- *  thumb, lightboxes the full. */
-export async function uploadAsset(file: File, token: string, stamp: number): Promise<Asset> {
+/** Upload one image to a per-item pool as a full + thumbnail webp; returns its
+ *  Asset (with EXIF geo + item ownership). Both variants are immutable-cached;
+ *  grids use the thumb, lightboxes the full. */
+export async function uploadAsset(
+  file: File,
+  token: string,
+  stamp: number,
+  type: ItemType,
+  slug: string,
+): Promise<Asset> {
   const geo = await readGeo(file)
   // `from-image` applies EXIF orientation so phone photos aren't sideways.
   const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
@@ -135,17 +141,19 @@ export async function uploadAsset(file: File, token: string, stamp: number): Pro
   const thumb = await encode(bitmap, 480, 0.72)
   bitmap.close?.()
   const id = `${stamp}-${slugifyName(file.name)}`
-  await putMedia(assetObject(id), full.blob, token, 'image/webp')
-  await putMedia(thumbObject(id), thumb.blob, token, 'image/webp')
+  await putMedia(assetObject(type, slug, id), full.blob, token, 'image/webp')
+  await putMedia(thumbObject(type, slug, id), thumb.blob, token, 'image/webp')
   return {
     id,
-    url: publicUrl(assetObject(id)),
-    thumb: publicUrl(thumbObject(id)),
+    url: publicUrl(assetObject(type, slug, id)),
+    thumb: publicUrl(thumbObject(type, slug, id)),
     alt: '',
     caption: '',
     width: full.width,
     height: full.height,
     slot: '',
+    itemType: type,
+    itemSlug: slug,
     ...geo,
   }
 }

--- a/lib/admin/storage.ts
+++ b/lib/admin/storage.ts
@@ -3,11 +3,16 @@ import { ADMIN } from './config'
 export type ItemType = 'blog' | 'hike'
 
 // GCS object layout (single bucket, all public-read):
-//   assets/<id>.webp              — the shared image pool
-//   library/index.json           — asset registry (catalogue + metadata)
-//   manifest/<type>/<slug>.json  — per-item assignment { hero, og, gallery[] }
-export const assetObject = (id: string) => `assets/${id}.webp`
-export const thumbObject = (id: string) => `assets/${id}-thumb.webp`
+//   assets/<type>/<slug>/<id>.webp  — per-item image pool
+//   library/index.json              — global asset registry (catalogue + metadata)
+//   manifest/<type>/<slug>.json     — per-item assignment { hero, og, gallery[] }
+//
+// Legacy flat pool (pre-namespacing): assets/<id>.webp. Existing assets keep
+// working because their full urls are stored in the registry/manifests.
+export const assetObject = (type: ItemType, slug: string, id: string) => `assets/${type}/${slug}/${id}.webp`
+export const thumbObject = (type: ItemType, slug: string, id: string) => `assets/${type}/${slug}/${id}-thumb.webp`
+export const legacyAssetObject = (id: string) => `assets/${id}.webp`
+export const legacyThumbObject = (id: string) => `assets/${id}-thumb.webp`
 export const manifestObject = (type: ItemType, slug: string) => `manifest/${type}/${slug}.json`
 export const libraryObject = () => 'library/index.json'
 

--- a/lib/gen/content.ts
+++ b/lib/gen/content.ts
@@ -169,6 +169,12 @@ export interface Asset {
   takenAt: string;
   /** small webp variant for grids (falls back to url) */
   thumb: string;
+  /** 'blog' | 'hike' — the item this asset was uploaded from */
+  itemType?:
+    | string
+    | undefined;
+  /** slug of the item this asset was uploaded from */
+  itemSlug?: string | undefined;
 }
 
 /**

--- a/proto/content.proto
+++ b/proto/content.proto
@@ -115,6 +115,8 @@ message Asset {
   double lng = 9;       // EXIF GPS longitude (0 = none)
   string taken_at = 10; // EXIF capture time (ISO), if present
   string thumb = 11;    // small webp variant for grids (falls back to url)
+  optional string item_type = 12; // 'blog' | 'hike' — the item this asset was uploaded from
+  optional string item_slug = 13; // slug of the item this asset was uploaded from
 }
 
 // Per-item image assignment, stored at manifest/<type>/<slug>.json (public-read,

--- a/public/blog/overland-track-guide/index.md
+++ b/public/blog/overland-track-guide/index.md
@@ -1,92 +1,80 @@
 ---
-title: The Overland Track — a trail guide
+title: The Overland Track in winter — a trail guide
 date: 2026-06-29T00:00:00.000Z
 description: >-
-  Tasmania's great alpine walk, end to end: six days from Cradle Mountain to
-  Lake St Clair, the huts you sleep in, the summits worth the detour, and what
-  grows and moves in the oldest wilderness in Australia.
+  Tasmania's great alpine walk in the quiet of winter: eight days from Cradle
+  Mountain to Lake St Clair, walking through snow, summiting side peaks, and
+  staying in the empty huts.
 labels: 'hiking, trail-guide'
 release: true
 heroImage: /blog/overland-track-guide/hero.webp
 takeaways:
   - >-
-    Sixty-five kilometres, six days, one direction. The core route is a string
-    of six huts from Cradle Mountain south to Lake St Clair, with the hardest
-    climb on the very first morning and the rest a long gentle shedding of
-    altitude.
+    The Overland Track is usually a six-day summer walk, but in winter it
+    becomes a slower, snowier, far quieter trip. Give yourself eight days if you
+    want to climb the side peaks without rushing.
   - >-
-    The best of the track is optional. Mount Ossa, Barn Bluff, the Du Cane
-    waterfalls and Pine Valley are all side trips off the main line — the
-    walkers who carry light and detour often see twice as much as those who only
-    tick the huts.
+    Black ice, hard snow and short days change the rhythm. Microspikes and a
+    four-season sleeping bag are not optional; neither is patience when the
+    shuttle can't run.
   - >-
-    This is Gondwana, not the Alps. Pandani, deciduous beech and
-    thousand-year-old King Billy pines grow nowhere else, and it can snow in any
-    month — pack for winter even in February.
+    The side trips are the reason you come. Mount Oakleigh at sunrise, Mount
+    Ossa on a clear day, and a frozen Lake Windermere reflecting Barn Bluff were
+    the moments that stuck.
 markdown_url: /blog/overland-track-guide/
 canonical_url: 'https://benebsworth.com/blog/overland-track-guide/'
 ---
 ## Key takeaways
 
-- Sixty-five kilometres, six days, one direction. The core route is a string of six huts from Cradle Mountain south to Lake St Clair, with the hardest climb on the very first morning and the rest a long gentle shedding of altitude.
-- The best of the track is optional. Mount Ossa, Barn Bluff, the Du Cane waterfalls and Pine Valley are all side trips off the main line — the walkers who carry light and detour often see twice as much as those who only tick the huts.
-- This is Gondwana, not the Alps. Pandani, deciduous beech and thousand-year-old King Billy pines grow nowhere else, and it can snow in any month — pack for winter even in February.
+- The Overland Track is usually a six-day summer walk, but in winter it becomes a slower, snowier, far quieter trip. Give yourself eight days if you want to climb the side peaks without rushing.
+- Black ice, hard snow and short days change the rhythm. Microspikes and a four-season sleeping bag are not optional; neither is patience when the shuttle can't run.
+- The side trips are the reason you come. Mount Oakleigh at sunrise, Mount Ossa on a clear day, and a frozen Lake Windermere reflecting Barn Bluff were the moments that stuck.
 
-The Overland Track is the walk most Australian hikers measure the others against. Sixty-five kilometres through the heart of the Cradle Mountain–Lake St Clair National Park, a slice of the Tasmanian Wilderness World Heritage Area, walked north to south over six unhurried days. You start beneath the serrated profile of Cradle Mountain and finish on the shore of the deepest natural lake in Australia, and in between you cross button-grass moorland, climb past glacial tarns, drop into rainforest older than the species walking through it, and sleep in a chain of well-built huts.
+I walked the Overland Track in mid-winter, at the end of July, when the booking quota is gone, the huts are almost empty, and the track can feel like it belongs to the people on it. A few weeks earlier I had used a six-hour hike up Mount Riddell, just outside Melbourne, as a warm-up. It was not enough. I was under-trained and a little de-conditioned, and I knew it. The one thing I had sorted was footwear: a pair of [Meindl Guffert boots](https://meindl.com.au/collections/all-mens-boots/products/guffert) that turned out to be worth every dollar on the frozen boardwalks and icy rock of the plateau.
 
-What makes it special is not difficulty. The main track is graded moderate and most of the real climbing is over by lunchtime on day one. What makes it special is the density of good things per kilometre, and the fact that so many of the best of them sit just off the line, waiting for anyone willing to drop their pack at a junction and walk an extra hour uphill. This guide lays out the route as it is usually walked, the side trips worth the legs, where you sleep, and what you are likely to see growing and moving around you.
+The standard Overland is a one-way, six-day summer traverse from Ronny Creek to Narcissus Hut, where most people ferry down Lake St Clair. In winter the days are short, the side trips take longer, and the huts are cold enough that you want to arrive with light left to make dinner. I stretched it to eight days, added two nights at Kia Ora, and would do the same again.
 
 > [TrailSummary component] Hero "at a glance" card for a trail guide. Shows the headline stats (distance, days on trail, total ascent, high point) with icons, a derived or explicit difficulty band (easy → extreme, trail-grade colour), and optional season window and gear class. An expandable "more" panel reveals secondary figures (avg km/day, ascent/day). The `hike` prop auto-binds the stats and accent colour from content/hiking.ts; an optional inline mini route map can be shown. The rendered post has the live, interactive card.
 
 ## The route
 
-The Overland runs one way, south from Ronny Creek in the Cradle Valley to Narcissus Hut at the head of Lake St Clair, where most walkers take the ferry down the lake to Cynthia Bay. Between October and May a southbound booking and a Parks pass are compulsory, and a daily quota keeps the huts from overflowing. The shape of it is simple: a steep start onto the high plateau, a long traverse south down the spine of the park, and a final descent into rainforest and lakeshore.
+The track runs south through the heart of Cradle Mountain–Lake St Clair National Park, a slice of the Tasmanian Wilderness World Heritage Area. You start in the button-grass flats of Cradle Valley, climb onto the alpine plateau on the first morning, then spend the next week traversing south: across moorland and tarns, through myrtle-beech rainforest, over the exposed saddle of Pelion Gap, beneath the Du Cane Range, and finally down to Lake St Clair. In winter the shape of the country does not change, but the colour does — snow on the dolerite, ice on the boardwalks, and the track reduced to a thin line between white hills.
 
 > [TrailMap component] Bespoke route map for a hike — a stylised topographic plate (not a geographic map) showing the trail as a smooth line through numbered waypoints over a faint contour backdrop, with a peak marker on the high point and an elevation-profile strip beneath. Driven by the hike's normalised waypoints and per-hike accent colour. The `hike` prop names a hike from content/hiking.ts to auto-bind its waypoints; alternatively pass explicit `waypoints`. The rendered post has the live, hoverable version.
 
 ## Day by day
 
-The six core stages below are the standard southbound itinerary. Distances are for the main track only — every side trip in the next section adds to the day. The numbers are forgiving: the longest day is the third, and even that is a gentle one once you are past the first morning's climb.
+These six stages are the spine of the route, but the numbers below reflect my winter timing — longer days, slower walking, and side trips folded in. If you are walking the standard summer itinerary you can compress days two and three, and skip the extra night at Kia Ora.
 
 > [Stages component] Wrapper for an ordered list of <Stage> day-segments, rendered as a vertical timeline with a topographic contour spine. Use it to lay out a trail day by day.
 
-<Stage day={1} from="Ronny Creek" to="Waterfall Valley" distanceKm={10.7} ascentM={520} descentM={300} timeHours="4–6 h" terrain="Boardwalk over button grass, then a steep stepped climb to the plateau; exposed alpine moorland after.">
+<Stage day={1} from="Ronny Creek" to="Waterfall Valley" distanceKm={10.7} ascentM={520} descentM={300} timeHours="5–7 h" terrain="Boardwalk, icy rock, and the steep climb onto the Cradle plateau.">
 
-The hardest morning of the whole walk comes first. From the boardwalk at Ronny Creek the track climbs past Crater Lake and up the chained, stepped pitch to Marions Lookout, the highest point on the standard route. Get this behind you and the rest of the day — and arguably the rest of the track — is downhill by comparison.
+The shuttle from Launceston was meant to drop us at Ronny Creek around 6 am, but black ice had closed the road beyond the information centre. We walked the extra kilometre or so to the trailhead in the half-dark, boots crunching on frozen gravel. It was a rough start, but it also meant I met the group I would walk with for the rest of the trip: three friends and two of their sons, all of them faster and funnier than I had any right to hike with.
+
+I had worried about deep Tasmanian winter snow — stories of walkers post-holing for days — but the cover was light and beautiful, more like a hard frost than an alpine blizzard. A little rain and snow fell in the first hour, then the sky cleared. We stopped at the Overland Track signpost for the obligatory photo, then climbed past Crater Lake and up the chained pitch to Marions Lookout.
+
+> [TrailFigure component] A real-photo figure for a trail guide: a single bordered photo (a co-located path or an absolute GCS URL) with an optional accent meta eyebrow (e.g. "Day 3 · Pas de Chèvres"), a caption and a credit. The photo-led counterpart to the researched Landmark/Stop cards — drop one inline for a single beat, or wrap several in a <TrailGrid> for a 2-up strip of trip photos. The rendered post shows the actual image.
+
+> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
 
 > [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
 
-> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+Beyond Kitchen Hut the track crosses the open plateau and drops into Waterfall Valley. We arrived at the hut in the late afternoon, around 4 or 5 pm, with enough time to make a proper dinner and settle in before the temperature dropped. The hut was empty except for our group. I made coffee on the bench and watched the light fade off Barn Bluff.
 
-Beyond Kitchen Hut the track crosses the open Cradle plateau and begins its long descent into Waterfall Valley, tucked under the dark bulk of Barn Bluff. The valley is exposed and weather rolls through fast, so most walkers are glad of the hut.
-
-> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+> [TrailFigure component] A real-photo figure for a trail guide: a single bordered photo (a co-located path or an absolute GCS URL) with an optional accent meta eyebrow (e.g. "Day 3 · Pas de Chèvres"), a caption and a credit. The photo-led counterpart to the researched Landmark/Stop cards — drop one inline for a single beat, or wrap several in a <TrailGrid> for a 2-up strip of trip photos. The rendered post shows the actual image.
 
 </Stage>
 
-<Stage day={2} from="Waterfall Valley" to="Lake Windermere" distanceKm={7.8} ascentM={150} descentM={250} timeHours="3–4 h" terrain="The easiest day — gentle moorland and boardwalk past alpine lakes and tarns.">
+<Stage day={2} from="Waterfall Valley" to="Lake Windermere" distanceKm={7.8} ascentM={150} descentM={250} timeHours="3–5 h" terrain="Gentle moorland, frozen boardwalk, and a short drop to the lake.">
 
-A short, kind day. With the big climb behind you, the track ambles south across moorland strung with tarns, passing the junction to Lake Will — a worthwhile hour's detour to a quiet alpine lake under Barn Bluff. Lake Windermere itself is a good swimming lake on the rare warm afternoon.
+I slept better than expected and woke up feeling fresh. That lasted about ten minutes. The track out of Waterfall Valley was sheet ice in patches, and before I had properly woken up I slipped, landed hard on my knee, and spent the next few minutes sitting in the snow waiting for the pain to tell me how bad it was.
 
-> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+It was bad enough that my first thought was the Garmin inReach Mini 2 in my pack and whether this was the helicopter moment. After a rest, a check of the joint, and some very careful walking, it seemed stable. I decided to push on slowly. The knee swelled over the next two days, but it held. I was lucky: the fall missed my patella and did no real structural damage.
 
-> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+> [TrailFigure component] A real-photo figure for a trail guide: a single bordered photo (a co-located path or an absolute GCS URL) with an optional accent meta eyebrow (e.g. "Day 3 · Pas de Chèvres"), a caption and a credit. The photo-led counterpart to the researched Landmark/Stop cards — drop one inline for a single beat, or wrap several in a <TrailGrid> for a 2-up strip of trip photos. The rendered post shows the actual image.
 
-</Stage>
-
-<Stage day={3} from="Lake Windermere" to="New Pelion" distanceKm={16.8} ascentM={300} descentM={420} timeHours="5–6 h" terrain="The longest day; long moorland traverse, then a descent through rainforest to the lowest point of the track and back up to Pelion Plains.">
-
-The longest stage, but not the hardest. The track runs south across moor and then drops steadily through myrtle-beech rainforest to Frog Flats, where it crosses the Forth River at the lowest point on the whole route. From there it climbs gently back to the open eucalypt of Pelion Plains, with the dolerite spires of Mount Oakleigh rising over the hut.
-
-> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
-
-> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
-
-</Stage>
-
-<Stage day={4} from="New Pelion" to="Kia Ora" distanceKm={8.6} ascentM={300} descentM={300} timeHours="3–4 h" terrain="A steady rainforest climb to the exposed alpine saddle of Pelion Gap, then down to Kia Ora.">
-
-A short day on paper, but the day most walkers build their trip around — because Pelion Gap is the launch point for Tasmania's highest mountain. The track climbs through rainforest from Pelion Plains onto the bare saddle of Pelion Gap, where the junctions for Mount Ossa and Mount Pelion East break off. Even if you climb neither, the gap itself is a fine, wind-scoured place to stand.
+We stopped for lunch beside a half-frozen lake with Barn Bluff rising behind it, then continued on to Lake Windermere Hut. That afternoon, with the knee throbbing and the day still clear, I waded into the lake. It was July in Tasmania, so "swim" is a generous word — more of a gasp, a float, and a rapid exit. But the cold took the swelling down better than anything in my first-aid kit, and the reset was worth the shock.
 
 > [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
 
@@ -94,9 +82,41 @@ A short day on paper, but the day most walkers build their trip around — becau
 
 </Stage>
 
-<Stage day={5} from="Kia Ora" to="Bert Nichols (Windy Ridge)" distanceKm={9.6} ascentM={300} descentM={350} timeHours="4–5 h" terrain="Rainforest beneath the Du Cane Range, past a cluster of waterfall side trips, over Du Cane Gap and down to Windy Ridge.">
+<Stage day={3} from="Lake Windermere" to="New Pelion" distanceKm={16.8} ascentM={300} descentM={420} timeHours="5–7 h" terrain="Long moorland traverse, then rainforest down to Frog Flats and back up to Pelion Plains.">
 
-The waterfall day. From Kia Ora the track threads beneath the towers of the Du Cane Range, passing the historic Du Cane Hut and a string of short side trips to D'Alton, Fergusson and Hartnett Falls — at their thundering best after rain. It then climbs to Du Cane Gap before dropping to Bert Nichols Hut at the head of the Narcissus valley.
+I gave myself a rest morning at Windermere. The lake was perfectly still at dawn, and Barn Bluff was reflected in the dark water with a clarity that made the early start feel easy. I took more photos than I needed, then packed up and left with the group in mid-morning.
+
+> [TrailFigure component] A real-photo figure for a trail guide: a single bordered photo (a co-located path or an absolute GCS URL) with an optional accent meta eyebrow (e.g. "Day 3 · Pas de Chèvres"), a caption and a credit. The photo-led counterpart to the researched Landmark/Stop cards — drop one inline for a single beat, or wrap several in a <TrailGrid> for a 2-up strip of trip photos. The rendered post shows the actual image.
+
+The longest day of the standard route, but not the hardest. The track runs south across open moor, drops through myrtle-beech rainforest to Frog Flats — the lowest point on the whole walk — and then climbs gently back to Pelion Plains. Mount Oakleigh's dolerite organ pipes come into view long before you reach the hut, and they dominated the evening light.
+
+> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+
+> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+
+</Stage>
+
+<Stage day={4} from="New Pelion" to="Kia Ora" distanceKm={8.6} ascentM={300} descentM={300} timeHours="4–6 h" terrain="Rainforest climb to Pelion Gap, then down to Kia Ora.">
+
+This was the day I built the trip around. I left New Pelion before dawn to climb Mount Oakleigh for sunrise, reaching the summit while the light was still thin and pink. There was enough phone reception at the top for one brief call, and I used it to call my then-girlfriend — now wife — Jess. It felt like a small miracle, a private conversation from the top of a mountain in the middle of Tasmania.
+
+By the time I got back to the hut the group was ready to move. We packed up, climbed through rainforest to Pelion Gap, and dropped down to Kia Ora Hut in the early afternoon. The gap itself is a wind-scoured saddle between Mount Ossa and Mount Pelion East, and the junction signposts point off in three directions: up, up, and down.
+
+> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+
+> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+
+> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+
+</Stage>
+
+<Stage day={5} from="Kia Ora" to="Bert Nichols (Windy Ridge)" distanceKm={9.6} ascentM={300} descentM={350} timeHours="4–5 h" terrain="Waterfall side trips, Du Cane Gap, and descent to Windy Ridge.">
+
+It was my birthday, and I did not remember until I got back to the hut. I spent the morning on a double side-quest: Mount Ossa first, then Mount Pelion East, returning to Kia Ora for lunch and a rest before pushing on. That is only possible if you are staying at Kia Ora a second night, which I was — it made the day feel generous rather than rushed.
+
+Mount Ossa is the reason many people walk the Overland. It is Tasmania's highest summit at 1,617 metres, and on a clear day the view takes in most of the park's named peaks. The route from Pelion Gap climbs through a scree gully and finishes on exposed boulders; under snow the rock is slick, and the drop on either side is real. Mount Pelion East is shorter and quieter, a good second summit if the legs are willing.
+
+After lunch we packed up and walked the waterfall section of the main track: past Du Cane Hut and the short detours to D'Alton, Fergusson and Hartnett Falls, then over Du Cane Gap and down to Bert Nichols Hut. The falls were running hard after winter rain, and the forest was thick with mist.
 
 > [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
 
@@ -108,35 +128,47 @@ The waterfall day. From Kia Ora the track threads beneath the towers of the Du C
 
 </Stage>
 
-<Stage day={6} from="Bert Nichols" to="Narcissus · Lake St Clair" distanceKm={9.0} ascentM={120} descentM={330} timeHours="3 h" terrain="A gentle, mostly downhill walk through forest to the lakeshore.">
+<Stage day={6} from="Bert Nichols" to="Narcissus · Lake St Clair" distanceKm={9.0} ascentM={120} descentM={330} timeHours="3 h" terrain="Mostly downhill forest walk to the lake shore.">
 
-The last morning is an easy, mostly downhill walk through forest to Narcissus Hut on the northern shore of Lake St Clair. Radio ahead to confirm the ferry from the hut, which carries most walkers down Australia's deepest lake to Cynthia Bay and the end of the track. Those with time and energy can instead walk the lakeshore the full 17.5 km to Cynthia Bay.
+The last morning was easy walking through forest to Narcissus Hut. I had planned to walk the full lakeshore track to Cynthia Bay, but the group was taking the ferry and I decided to join them. The lakeshore route is reputedly muddy and less well maintained, and after eight days — and a bruised knee — the ferry was the smarter finish. It also gave us time to make the shuttle back to Launceston and find a proper meal.
+
+> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
 
 > [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
 
-> [Checkpoint component] Inline milestone/checkpoint marker, usable in prose or inside a <Stage>: an icon (pass, summit, water, junction, viewpoint, camp, hut or generic milestone), a name, an optional altitude, and an optional note. Marks the key points along a day's walk.
+We landed back in Launceston in the early evening, dirty and tired, and went straight to a restaurant for the kind of meal that only tastes that good at the end of a long walk. I cannot remember what I ordered; I remember the relief.
+
+> [TrailFigure component] A real-photo figure for a trail guide: a single bordered photo (a co-located path or an absolute GCS URL) with an optional accent meta eyebrow (e.g. "Day 3 · Pas de Chèvres"), a caption and a credit. The photo-led counterpart to the researched Landmark/Stop cards — drop one inline for a single beat, or wrap several in a <TrailGrid> for a 2-up strip of trip photos. The rendered post shows the actual image.
 
 </Stage>
 
 ## Side trips
 
-The walkers who get the most out of the Overland are the ones who treat the huts as a baseline and the summits as the point. Each of these leaves from a junction on the main track; carry water, weather gear and a light day load, and leave the big pack at the junction. None should be attempted in cloud, high wind or snow — the upper sections are exposed boulder scrambles where a whiteout is genuinely dangerous.
+The main track is the skeleton; the side trips are the reason you carry a light day pack. In winter they take longer and demand better weather, but the emptiness of the huts means you can schedule rest days around them.
 
 > [Quest component] A "side-quest" card: an optional detour or side-trip off the main trail (a side summit, a hidden gorge), framed playfully but informatively with the extra distance, ascent and time it costs, how much harder it is, and the payoff for doing it.
 
-The classic detour, leaving from Pelion Gap on day four. The route contours around Mount Doris to a saddle with fine views, then climbs steeply through a scree gully and over boulders to the summit at 1,617 metres. Allow four to five hours of daylight to summit and return to the gap, plus the hour down to Kia Ora. Save it for a clear, settled day — the boulder field is treacherous under snow.
+Leaves from Pelion Gap on the climb up from New Pelion. The route contours around Mount Doris, then climbs a scree gully and finishes on exposed boulders. Under snow the boulders are treacherous — save it for a settled, clear day. I combined it with Mount Pelion East in a single long birthday morning, but most walkers should allow a full day.
 
 > [Quest component] A "side-quest" card: an optional detour or side-trip off the main trail (a side summit, a hidden gorge), framed playfully but informatively with the extra distance, ascent and time it costs, how much harder it is, and the payoff for doing it.
 
-The dark, blunt peak that dominates the first two days. The side trip leaves from near the day-one junction below Waterfall Valley, climbing steeply with some boulder scrambling to the 1,559-metre summit. Fine weather only — the upper mountain is exposed and the scramble is no place to be in cloud.
+Also from Pelion Gap. The route is shorter and less committing than Ossa, which makes it a good second summit if you have the legs and the weather. I tagged it after Ossa on the same morning and was back at Kia Ora for lunch.
 
 > [Quest component] A "side-quest" card: an optional detour or side-trip off the main trail (a side summit, a hidden gorge), framed playfully but informatively with the extra distance, ascent and time it costs, how much harder it is, and the payoff for doing it.
 
-The longest detour, and best done as an extra night rather than a rushed day. The track to Pine Valley Hut leaves the main line about 5 km short of Narcissus; from the hut, the Acropolis is a serious all-day scramble up to 1,471 metres, and the Labyrinth a gentler wander through a plateau of tarns. Carry overnight gear and a route-finding head — this is the wildest country the trip touches.
+A pre-dawn climb from New Pelion Hut. The summit is lower than Ossa but the morning light on the dolerite pipes and the view back toward the plateau make it feel like the best-kept secret of the walk. There was enough reception at the top for a phone call, which is not something I expected in the Tasmanian wilderness.
+
+> [Quest component] A "side-quest" card: an optional detour or side-trip off the main trail (a side summit, a hidden gorge), framed playfully but informatively with the extra distance, ascent and time it costs, how much harder it is, and the payoff for doing it.
+
+The dark peak that dominates the first two days. The side trip leaves from near Waterfall Valley Hut and involves some boulder scrambling near the top. In winter the upper mountain holds snow and the rock is slick; fine weather only.
+
+> [Quest component] A "side-quest" card: an optional detour or side-trip off the main trail (a side summit, a hidden gorge), framed playfully but informatively with the extra distance, ascent and time it costs, how much harder it is, and the payoff for doing it.
+
+Best done as an extra night rather than a day trip. The turn-off is about 5 km before Narcissus. I skipped it this time, but it is the obvious reason to come back.
 
 ## Where you sleep
 
-The core track has a hut at the end of each of the first five days, with platforms for tents alongside. The huts are unstaffed and unbookable individually — you book the track, not the bed — so they run first-come, and on a busy night the overflow tents on the platforms. Carry a stove and full sleeping kit regardless; the huts have no mattresses, no power and no guaranteed space.
+The huts are unstaffed, unheated, and run on a first-come basis within your track booking. In winter they are rarely full, but the cold is the real constraint — carry a four-season bag, a full sleeping kit, and a stove regardless of whether you plan to tent. The platforms outside are for overflow in summer; in winter you want to be inside.
 
 > [TrailGrid component] Responsive grid wrapper (1–3 columns) for laying out Stop / Landmark / Flora / Fauna cards side by side.
 
@@ -154,133 +186,95 @@ The core track has a hut at the end of each of the first five days, with platfor
 
 ## Landmarks
 
-A handful of features anchor the walk, and you measure your progress against them — the peak that watches over the first days, the lake that ends it, the dolerite that frames the middle.
-
 > [TrailGrid component] Responsive grid wrapper (1–3 columns) for laying out Stop / Landmark / Flora / Fauna cards side by side.
 
 <Landmark name="Cradle Mountain" kind="summit" elevM={1545} bearing="N from the start">
-
-The serrated dolerite skyline that gives the park its name and the track its opening image. The summit itself is an optional scramble from Kitchen Hut on day one — a stiff couple of hours of boulder hopping for a view over the whole northern end of the park.
-
+The serrated skyline that gives the park its name. The summit scramble from Kitchen Hut is harder under snow; many winter walkers skip it.
 </Landmark>
 
 <Landmark name="Barn Bluff" kind="summit" elevM={1559} bearing="S of Cradle">
-
-The blunt, dark cone that dominates the first two days. Lower than Cradle but more isolated, it is one of the most recognisable peaks in the park and a popular early side trip.
-
+The blunt cone that dominates the first two days. Photogenic from almost every angle, especially reflected in the lakes near Waterfall Valley and Windermere.
 </Landmark>
 
 <Landmark name="Mount Ossa" kind="summit" elevM={1617} bearing="W of Pelion Gap">
-
-Tasmania's highest mountain, and the high point of the whole walk if you climb it. A steep scramble from Pelion Gap delivers a summit panorama over most of the park's named peaks.
-
+Tasmania's highest mountain and the high point of the walk. A clear-day scramble from Pelion Gap.
 </Landmark>
 
 <Landmark name="Mount Oakleigh" kind="summit" elevM={1280} bearing="N over Pelion">
-
-The wall of dolerite organ-pipes that frames the view north from New Pelion Hut — one of the most photographed outlooks on the track, especially at sunset.
-
+The dolerite wall above New Pelion Hut. The sunrise summit is one of the best on the track.
 </Landmark>
 
-<Landmark name="The Acropolis" kind="summit" elevM={1471} bearing="E of Du Cane Gap">
-
-The great rampart of the Du Cane Range, reached only via the Pine Valley side trip. Its spires look unclimbable but yield a scrambler's route to the top.
-
+<Landmark name="Lake Windermere" kind="lake" bearing="Day 2">
+A small alpine lake that freezes at the edges in winter. The reflections of Barn Bluff at dawn are worth a rest day.
 </Landmark>
 
 <Landmark name="Lake St Clair" kind="lake" elevM={737} bearing="S terminus">
-
-The deepest natural lake in Australia, carved by glaciers, and the end of the line. The ferry down the lake from Narcissus is the traditional finish to the walk.
-
+The deepest natural lake in Australia. The ferry from Narcissus is the traditional finish.
 </Landmark>
 
 ## What grows here
 
-This is Gondwanan country — the plants here trace back to a supercontinent, and many grow nowhere else on Earth. Between two-fifths and over half of the park's alpine flora is endemic to Tasmania, much of it ancient, slow-growing and intolerant of fire. Tread the boardwalk and stay off the cushion plants; some of what you are walking past has been growing since before the printing press.
+This is Gondwanan country, and in winter it strips down to its structure: snow on the dolerite, dark green myrtle-beech in the gullies, and the pale trunks of pencil pines against the white hills.
 
 > [TrailGrid component] Responsive grid wrapper (1–3 columns) for laying out Stop / Landmark / Flora / Fauna cards side by side.
 
 <Flora name="Pandani" latin="Richea pandanifolia" when="Year-round" where="Crater Lake, rainforest edges">
-
-The tallest heath plant in the world, and unmistakable: a shaggy palm-like crown of long spined leaves on a single trunk. It looks tropical and is anything but — a hardy Tasmanian alpine endemic, thickest around Crater Lake on the first morning.
-
+The tallest heath plant in the world, a shaggy palm-like crown of strappy leaves that looks tropical and is anything but.
 </Flora>
 
 <Flora name="Deciduous beech (fagus)" latin="Nothofagus gunnii" when="Colour in late April" where="Alpine slopes, tarn shelves">
-
-Australia's only winter-deciduous native tree, and a Tasmanian endemic. For most of the year it is an unremarkable low scrub, but in late April its crinkled leaves turn gold and rust in a brief blaze the locals simply call "the turning of the fagus".
-
+Australia's only winter-deciduous native tree. In late April its leaves turn gold and rust in "the turning of the fagus".
 </Flora>
 
 <Flora name="King Billy pine" latin="Athrotaxis selaginoides" when="Year-round" where="Sheltered rainforest gullies">
+A Gondwanan conifer; some standing on the track are more than a thousand years old.
+</Flora>
 
-A Gondwanan conifer, cousin to the Californian redwoods, with soft russet bark and a slow, slow growth. Some standing on the track are more than a thousand years old; a fire that kills them is a loss measured in millennia.
-
+<Flora name="Pencil pine" latin="Athrotaxis cupressoides" when="Year-round" where="Alpine lake edges">
+Pale-barked and slow-growing, often the only tree around the frozen tarns of the central plateau.
 </Flora>
 
 <Flora name="Button grass" latin="Gymnoschoenus sphaerocephalus" when="Year-round" where="Open moorland plains">
-
-The tussocky sedge that defines the open moorland, named for the round seed-heads bobbing on long stems. It carpets the plains between the high points and gives the lower track its characteristic tea-coloured, peaty ground.
-
-</Flora>
-
-<Flora name="Cushion plants" latin="Abrotanella, Donatia spp." when="Year-round" where="Exposed alpine flats">
-
-Tight green mounds that look like moss but are dense colonies of tiny flowering plants, packed hard against the alpine wind. They grow agonisingly slowly and a single bootprint can scar them for years — which is why the boardwalk exists.
-
+The tussocky sedge that carpets the plains between the high points.
 </Flora>
 
 <Flora name="Myrtle beech" latin="Nothofagus cunninghamii" when="Year-round" where="Temperate rainforest">
-
-The backbone of the cool temperate rainforest the track drops into at Frog Flats and below the Du Cane Range — dark, small-leaved canopy over a deep moss understorey, another survivor of the Gondwanan flora.
-
+The backbone of the cool temperate rainforest below Frog Flats and the Du Cane Range.
 </Flora>
 
 ## What lives here
 
-The animals are mostly nocturnal and most reliably seen at dusk around the huts and at the Ronny Creek boardwalk at either end of the day. Keep food sealed and packs closed — the black currawongs in particular are practised thieves — and watch where you put your hands and feet in the warmer months, when tiger snakes are about.
+Most animals keep a low profile in winter, but the huts still attract black currawongs, and wombat tracks crisscross the snow around Ronny Creek at dawn.
 
 > [TrailGrid component] Responsive grid wrapper (1–3 columns) for laying out Stop / Landmark / Flora / Fauna cards side by side.
 
 <Fauna name="Common wombat" latin="Vombatus ursinus" likelihood="common" where="Ronny Creek, trailsides at dusk">
-
-The most reliable large sighting on the track. Wombats graze the button-grass flats around Ronny Creek at dawn and dusk, unbothered by walkers; give them room and they will keep cropping grass beside the boardwalk.
-
+The most reliable large sighting. Give them room and they will keep cropping grass beside the boardwalk.
 </Fauna>
 
 <Fauna name="Bennett's wallaby" latin="Notamacropus rufogriseus" likelihood="common" where="Open moorland, around huts">
-
-The larger of the two common macropods, often around the huts at dusk. Told from the pademelon by its longer legs and tail, rufous neck and the dark stripe down its face.
-
+Often around the huts at dusk, with a rufous neck and dark face stripe.
 </Fauna>
 
 <Fauna name="Tasmanian pademelon" latin="Thylogale billardierii" likelihood="common" where="Forest edges, hut clearings">
-
-A small, round, short-tailed wallaby of the forest understorey, and one of the most-seen animals around camp after dark. Endemic to Tasmania and the islands of Bass Strait.
-
+A small, round, short-tailed wallaby endemic to Tasmania.
 </Fauna>
 
 <Fauna name="Short-beaked echidna" latin="Tachyglossus aculeatus" likelihood="occasional" where="Open woodland and moorland">
-
-A spiny, ant-eating monotreme that potters across the track in daylight, snout down. Unhurried and unbothered; if disturbed it simply digs in or rolls into a spined ball.
-
+A spiny monotreme often seen pottering across the track in daylight.
 </Fauna>
 
 <Fauna name="Black currawong" latin="Strepera fuliginosa" likelihood="common" where="Huts and campsites">
-
-A large, glossy-black, yellow-eyed bird endemic to Tasmania, and the resident opportunist at every hut. Bold and clever — it will work zips and open lids, so hang or seal anything edible.
-
+A large, glossy-black, yellow-eyed bird endemic to Tasmania. It will open zips and lids — seal your food.
 </Fauna>
 
 <Fauna name="Tasmanian devil" latin="Sarcophilus harrisii" likelihood="rare" where="Nocturnal, forested sections">
-
-The island's marsupial carnivore — stocky, black, and far more often heard than seen. A sighting is a rare privilege; most walkers know it only by the screeching from the dark and the tracks at the hut edge.
-
+More often heard than seen. A sighting is a rare privilege.
 </Fauna>
 
 ## Gear
 
-The single rule that shapes the kit list: it can snow on the Overland in any month, and the weather can turn from sun to sleet in under an hour. Pack for winter even in midsummer. Beyond the four-season layers, you carry your own shelter and stove regardless of the huts, because a full hut on a bad night means a tent on a platform.
+Winter changes the kit list. Snow, ice and sub-zero hut nights are the baseline, not the exception. The four-season sleeping bag is non-negotiable, and so is the ability to make hot food and drinks in a hut with no cooking facilities.
 
 > [GearList component] Gear checklist for the trail, grouped into Worn / In the pack / Safety / Optional. Each <Gear> item can be flagged essential and carry a short note. Renders as a two-column grouped list.
 
@@ -318,4 +312,8 @@ The single rule that shapes the kit list: it can snow on the Overland in any mon
 
 > [Gear component] A single gear item inside a <GearList> (name, group, essential flag, note). Data-only — it is rendered by its parent <GearList>.
 
-The Overland rewards the walker who comes prepared for worse weather than they get, and who carries light enough to say yes to the side trips. Book early, watch the forecast, climb Ossa on the clear day, and let the rain days be the ones you spend in the rainforest among the thousand-year-old pines. That is the trip people come back from changed.
+> [Gear component] A single gear item inside a <GearList> (name, group, essential flag, note). Data-only — it is rendered by its parent <GearList>.
+
+> [Gear component] A single gear item inside a <GearList> (name, group, essential flag, note). Data-only — it is rendered by its parent <GearList>.
+
+The Overland in winter is not the same walk as the Overland in summer. It is slower, colder, and emptier. The side trips take longer, the days end earlier, and a slip on ice can turn a good morning into a serious decision. But the huts are quiet, the snow turns the plateau into something elemental, and the moments that matter — a sunrise on Mount Oakleigh, a frozen lake reflecting Barn Bluff, a phone call from a summit, a birthday spent climbing two mountains — feel earned in a way that fair-weather walking rarely does. Pack for the cold, give yourself the extra days, and say yes to the detours.

--- a/tools/hike-annotate/.gitignore
+++ b/tools/hike-annotate/.gitignore
@@ -1,0 +1,4 @@
+.cache/
+node_modules/
+*.write.json
+*.backup.*.json

--- a/tools/hike-annotate/bin/annotate.mjs
+++ b/tools/hike-annotate/bin/annotate.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Hike photo annotator CLI.
+//   node tools/hike-annotate/bin/annotate.mjs <slug> [--limit N] [--hint "..."]
+//                                              [--concurrency N] [--write] [--yes]
+// Default = dry-run: classify + place, write a review report, print a summary.
+// --write applies the proposed manifest to GCS (after a local backup); refuses
+// on a PARTIAL (limited) run and prompts for confirmation unless --yes.
+import { annotateHike } from '../src/pipeline.mjs'
+import { writeReport } from '../src/report.mjs'
+import { writeManifest, backupManifest } from '../src/manifest.mjs'
+import { saveProposal, loadProposal } from '../src/proposal-cache.mjs'
+import { createInterface } from 'node:readline/promises'
+
+function parseArgs(argv) {
+  const a = { slug: '', limit: Infinity, hint: '', concurrency: 4, write: false, yes: false, apply: false }
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i]
+    if (t === '--limit') a.limit = Number(argv[++i])
+    else if (t === '--hint') a.hint = argv[++i]
+    else if (t === '--concurrency') a.concurrency = Number(argv[++i])
+    else if (t === '--write') a.write = true
+    else if (t === '--apply') a.apply = true
+    else if (t === '--yes' || t === '-y') a.yes = true
+    else if (!t.startsWith('-') && !a.slug) a.slug = t
+  }
+  return a
+}
+
+const args = parseArgs(process.argv.slice(2))
+if (!args.slug) {
+  console.error('usage: annotate <hike-slug> [--limit N] [--hint "Country"] [--concurrency N] [--write|--apply] [--yes]')
+  process.exit(1)
+}
+
+async function confirmWrite(prompt) {
+  if (args.yes) return true
+  const rl = createInterface({ input: process.stdin, output: process.stderr })
+  const ans = (await rl.question(prompt)).trim()
+  rl.close()
+  return ans === 'yes'
+}
+
+// --apply: write a previously-cached proposal to GCS WITHOUT re-classifying.
+if (args.apply) {
+  const cached = await loadProposal(args.slug).catch(() => null)
+  if (!cached) {
+    console.error(`✗ no cached proposal for ${args.slug}. Run a dry-run first.`)
+    process.exit(2)
+  }
+  if (cached.partial) {
+    console.error(`✗ cached proposal for ${args.slug} is PARTIAL (limit was set). Re-run without --limit.`)
+    process.exit(2)
+  }
+  console.error(`▸ applying cached proposal for ${args.slug} (${cached.proposal.gallery.length} photos, saved ${cached.savedAt})`)
+  if (!(await confirmWrite('Write this cached manifest to GCS (live)? type "yes": '))) {
+    console.error('aborted.')
+    process.exit(0)
+  }
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  await backupManifest(args.slug, cached.manifest, cached.dir, stamp)
+  const uri = await writeManifest(args.slug, cached.proposal, cached.dir)
+  console.error(`✓ wrote ${uri}\n  live: https://benebsworth.com/hiking/${args.slug}/`)
+  process.exit(0)
+}
+
+const t0 = Date.now()
+console.error(`▸ annotating "${args.slug}"${Number.isFinite(args.limit) ? ` (limit ${args.limit})` : ''} via agy …`)
+const run = await annotateHike(args.slug, {
+  limit: args.limit,
+  hint: args.hint,
+  concurrency: args.concurrency,
+  onProgress: (done, total, id, cls) =>
+    console.error(`  [${String(done).padStart(2)}/${total}] ${id} → ${cls.waypoint || cls.geoWaypoint || '?'}${cls.skip ? ' (skip)' : ''}`),
+})
+
+const reportPath = await writeReport(run)
+const saved = await saveProposal(args.slug, run, reportPath, new Date().toISOString())
+const placed = run.metas.filter((m) => m.slot).length
+const skips = run.metas.filter((m) => m.skip).length
+const manual = run.metas.filter((m) => m.needsManual).length
+const byWp = {}
+for (const m of run.metas) byWp[m.slot || '(unplaced)'] = (byWp[m.slot || '(unplaced)'] || 0) + 1
+
+console.error(`\n✓ ${run.metas.length} classified in ${((Date.now() - t0) / 1000).toFixed(0)}s — ${placed} placed, ${skips} skip, ${manual} manual`)
+console.error(`  hero: ${run.heroId || 'none'}`)
+console.error(`  placement: ${Object.entries(byWp).map(([k, v]) => `${k}:${v}`).join('  ')}`)
+console.error(`\n  review report → ${saved.reportPath}`)
+console.error(`  open: open "${saved.reportPath}"`)
+console.error(`  proposal cached — apply later with: --apply`)
+
+if (!args.write) {
+  console.error('\n(dry-run — re-run with --write to apply now, or --apply once reviewed)')
+  process.exit(0)
+}
+if (run.partial) {
+  console.error('\n✗ refusing to --write a PARTIAL run (--limit set). Re-run without --limit.')
+  process.exit(2)
+}
+if (!(await confirmWrite('\nWrite this manifest to GCS (live)? type "yes": '))) {
+  console.error('aborted.')
+  process.exit(0)
+}
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+const backup = await backupManifest(args.slug, run.manifest, run.tmpDir, stamp)
+console.error(`  backup of current manifest → ${backup}`)
+const uri = await writeManifest(args.slug, run.proposal, run.tmpDir)
+console.error(`✓ wrote ${uri}`)
+console.error(`  live: https://${process.env.HIKE_SITE || 'benebsworth.com'}/hiking/${args.slug}/`)

--- a/tools/hike-annotate/mcp/server.mjs
+++ b/tools/hike-annotate/mcp/server.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// MCP server exposing the hike photo annotator. Tools:
+//   list_hikes_with_photos · propose_annotations · get_proposal_report · write_manifest
+// Auth: agy for classification (its own login), gsutil/gcloud (pinned account) for GCS.
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { annotateHike } from '../src/pipeline.mjs'
+import { writeReport } from '../src/report.mjs'
+import { writeManifest, backupManifest, readManifest, readLibrary, mergeLibraryAssets } from '../src/manifest.mjs'
+import { saveProposal, loadProposal } from '../src/proposal-cache.mjs'
+import { BUCKET, GCLOUD_ACCOUNT, manifestPublicUrl } from '../src/config.mjs'
+
+const pexec = promisify(execFile)
+const text = (o) => ({ content: [{ type: 'text', text: typeof o === 'string' ? o : JSON.stringify(o, null, 2) }] })
+const err = (s) => ({ content: [{ type: 'text', text: s }], isError: true })
+
+const server = new McpServer({ name: 'hike-annotate', version: '0.1.0' })
+
+server.tool(
+  'list_hikes_with_photos',
+  'List hikes whose manifest or namespaced library has gallery photos, with how many are unplaced (no slot).',
+  {},
+  async () => {
+    const [{ stdout }, library] = await Promise.all([
+      pexec('gsutil', ['ls', `gs://${BUCKET}/manifest/hike/`], {
+        env: { ...process.env, CLOUDSDK_CORE_ACCOUNT: GCLOUD_ACCOUNT },
+      }).catch(() => ({ stdout: '' })),
+      readLibrary(),
+    ])
+    const slugs = stdout
+      .split('\n')
+      .map((l) => l.match(/manifest\/hike\/(.+)\.json$/)?.[1])
+      .filter(Boolean)
+    // Also include hikes that have assets in the library but no manifest yet.
+    for (const a of library) {
+      if (a.itemType === 'hike' && a.itemSlug && !slugs.includes(a.itemSlug)) slugs.push(a.itemSlug)
+    }
+    const rows = []
+    for (const slug of slugs) {
+      const m = await readManifest(slug)
+      const gallery = mergeLibraryAssets(m, library, slug)
+      rows.push({ slug, photos: gallery.length, unplaced: gallery.filter((a) => !a.slot).length })
+    }
+    return text(rows)
+  },
+)
+
+server.tool(
+  'propose_annotations',
+  'Classify + geo-place every photo of a hike with agy; produce a proposed manifest + an HTML review report. Does NOT write to GCS.',
+  { slug: z.string(), limit: z.number().optional(), hint: z.string().optional(), concurrency: z.number().optional() },
+  async ({ slug, limit, hint, concurrency }) => {
+    const run = await annotateHike(slug, { limit: limit ?? Infinity, hint: hint ?? '', concurrency: concurrency ?? 4 })
+    const reportPath = await writeReport(run)
+    const saved = await saveProposal(slug, run, reportPath, new Date().toISOString())
+    const byWp = {}
+    for (const m of run.metas) byWp[m.slot || '(unplaced)'] = (byWp[m.slot || '(unplaced)'] || 0) + 1
+    return text({
+      slug,
+      photos: run.metas.length,
+      placed: run.metas.filter((m) => m.slot).length,
+      skip: run.metas.filter((m) => m.skip).length,
+      manual: run.metas.filter((m) => m.needsManual).length,
+      hero: run.heroId,
+      partial: run.partial,
+      placement: byWp,
+      reportPath: saved.reportPath,
+    })
+  },
+)
+
+server.tool(
+  'get_proposal_report',
+  'Get the cached proposal summary + report path for a hike (from the last propose_annotations).',
+  { slug: z.string() },
+  async ({ slug }) => {
+    const p = await loadProposal(slug).catch(() => null)
+    if (!p) return text(`No proposal cached for ${slug}. Run propose_annotations first.`)
+    return text({ slug, partial: p.partial, heroId: p.heroId, reportPath: p.reportPath, galleryCount: p.proposal.gallery.length })
+  },
+)
+
+server.tool(
+  'write_manifest',
+  'Write the cached proposed manifest for a hike to GCS (LIVE). Requires confirm:true and a non-partial proposal.',
+  { slug: z.string(), confirm: z.boolean() },
+  async ({ slug, confirm }) => {
+    if (!confirm) return err('Refused: pass confirm:true to write the live manifest.')
+    const p = await loadProposal(slug).catch(() => null)
+    if (!p) return err(`No proposal cached for ${slug}. Run propose_annotations first.`)
+    if (p.partial) return err(`Refused: cached proposal for ${slug} is PARTIAL (limit was set). Re-run propose_annotations without limit.`)
+    await backupManifest(slug, p.manifest, p.dir, new Date().toISOString().replace(/[:.]/g, '-'))
+    const uri = await writeManifest(slug, p.proposal, p.dir)
+    return text(`Wrote ${uri} (${p.proposal.gallery.length} photos). Live manifest: ${manifestPublicUrl(slug)}`)
+  },
+)
+
+await server.connect(new StdioServerTransport())

--- a/tools/hike-annotate/package-lock.json
+++ b/tools/hike-annotate/package-lock.json
@@ -1,0 +1,1177 @@
+{
+  "name": "@bnb/hike-annotate",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bnb/hike-annotate",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "hike-annotate": "bin/annotate.mjs"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/hike-annotate/package.json
+++ b/tools/hike-annotate/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@bnb/hike-annotate",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Gemini (Antigravity `agy`)-driven hike photo classifier + geo-placer for the benebsworth.com GCS image manifests. Reads a hike's manifest, geocodes its waypoints, geo-matches each already-geo-tagged photo, classifies it with agy (caption/alt/scene/waypoint/hero/skip), proposes an annotated manifest + a review report, and writes back to GCS on approval.",
+  "bin": {
+    "hike-annotate": "bin/annotate.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
+  }
+}

--- a/tools/hike-annotate/scripts/classify-one.mjs
+++ b/tools/hike-annotate/scripts/classify-one.mjs
@@ -1,0 +1,25 @@
+// Classify a single image end-to-end (geo candidates + agy). For smoke-testing.
+//   node tools/hike-annotate/scripts/classify-one.mjs <slug> <imagePath> <lat> <lng> [dir] [hint]
+import { getWaypoints, getHikeMeta } from '../src/waypoints.mjs'
+import { geocodeWaypoints } from '../src/geocode.mjs'
+import { nearestWaypoint } from '../src/geo.mjs'
+import { classifyImage } from '../src/classify.mjs'
+
+const [, , slug, imagePath, latS, lngS, dir = '/tmp', hint = 'Switzerland'] = process.argv
+const lat = parseFloat(latS)
+const lng = parseFloat(lngS)
+
+const [meta, wps] = await Promise.all([getHikeMeta(slug), getWaypoints(slug)])
+const geo = await geocodeWaypoints(wps, hint)
+const n = nearestWaypoint({ lat, lng }, geo)
+const ctx = {
+  hike: meta,
+  waypoints: geo,
+  candidates: n.ranked.slice(0, 3).map((r) => ({ name: r.name, km: +r.km.toFixed(1) })),
+  takenAt: '',
+}
+console.error('geo candidates:', JSON.stringify(ctx.candidates))
+const t0 = Date.now()
+const cls = await classifyImage(imagePath, dir, ctx)
+console.error(`agy took ${((Date.now() - t0) / 1000).toFixed(1)}s`)
+console.log(JSON.stringify(cls, null, 2))

--- a/tools/hike-annotate/scripts/geomatch-dry.mjs
+++ b/tools/hike-annotate/scripts/geomatch-dry.mjs
@@ -1,0 +1,46 @@
+// Dry-run: geo-match every gallery photo of a hike to its nearest waypoint.
+// No agy, no writes — validates the geo half against the real manifest.
+//   node tools/hike-annotate/scripts/geomatch-dry.mjs [slug] [geocode-hint]
+import { readManifest } from '../src/manifest.mjs'
+import { getWaypoints, getHikeMeta } from '../src/waypoints.mjs'
+import { geocodeWaypoints } from '../src/geocode.mjs'
+import { nearestWaypoint, chronologyConflicts } from '../src/geo.mjs'
+
+const slug = process.argv[2] || 'haute-route'
+const hint = process.argv[3] || 'Switzerland'
+
+const [meta, wps, manifest] = await Promise.all([getHikeMeta(slug), getWaypoints(slug), readManifest(slug)])
+const geo = await geocodeWaypoints(wps, hint)
+
+console.log(`\n${meta.name} — ${meta.region}, ${meta.country} (${meta.year})`)
+console.log('Geocoded waypoints:')
+for (const g of geo) console.log(`  ${g.day.padEnd(7)} ${g.name.padEnd(12)} ${Number.isFinite(g.lat) ? `${g.lat.toFixed(4)}, ${g.lng.toFixed(4)}` : '(no geo)'}  ${g.elev} m`)
+
+const placed = manifest.gallery.map((a) => {
+  if (!a.lat && !a.lng) return { id: a.id, slot: '', km: null, takenAt: a.takenAt, noGeo: true }
+  const n = nearestWaypoint({ lat: a.lat, lng: a.lng }, geo)
+  return { id: a.id, slot: n.waypoint, km: +n.km.toFixed(2), takenAt: a.takenAt, second: n.ranked[1] }
+})
+
+const counts = {}
+for (const p of placed) counts[p.slot || '(no geo)'] = (counts[p.slot || '(no geo)'] || 0) + 1
+const conflicts = chronologyConflicts(placed, geo)
+
+console.log(`\n${manifest.gallery.length} photos → geo-nearest waypoint:`)
+for (const g of geo) console.log(`  ${String(counts[g.name] || 0).padStart(3)}  ${g.name}`)
+if (counts['(no geo)']) console.log(`  ${String(counts['(no geo)']).padStart(3)}  (no geo)`)
+console.log(`\nMedian/maX nearest distance: ${distStats(placed.filter((p) => p.km != null).map((p) => p.km))}`)
+console.log(`Chronology conflicts (geo vs takenAt order): ${conflicts.size}`)
+
+console.log('\nChronological sample (first 14 by takenAt):')
+for (const p of placed.filter((p) => p.takenAt).sort((a, b) => String(a.takenAt).localeCompare(String(b.takenAt))).slice(0, 14)) {
+  const flag = conflicts.has(p.id) ? ' ⚠chrono' : ''
+  console.log(`  ${String(p.takenAt).slice(0, 16).replace('T', ' ')}  →  ${(p.slot || '(no geo)').padEnd(12)} ${p.km != null ? `${p.km} km` : ''}${flag}`)
+}
+
+function distStats(arr) {
+  if (!arr.length) return 'n/a'
+  const s = [...arr].sort((a, b) => a - b)
+  const med = s[Math.floor(s.length / 2)]
+  return `${med.toFixed(2)} km / ${s[s.length - 1].toFixed(2)} km`
+}

--- a/tools/hike-annotate/src/classify.mjs
+++ b/tools/hike-annotate/src/classify.mjs
@@ -1,0 +1,112 @@
+import { spawn } from 'node:child_process'
+import { AGY_BIN, AGY_MODEL } from './config.mjs'
+
+export const SCENE_TYPES = [
+  'summit', 'pass', 'lake', 'hut', 'glacier', 'town', 'valley', 'ridge',
+  'trail', 'forest', 'river', 'wildlife', 'flora', 'person', 'food', 'other',
+]
+
+function buildPrompt(imagePath, ctx) {
+  const cand = ctx.candidates.map((c) => `${c.name} (${c.km} km)`).join(', ')
+  const route = ctx.waypoints.map((w) => `${w.name} (${w.day})`).join(' → ')
+  return [
+    'You are classifying ONE photo for a hiking trip photo gallery.',
+    `Hike: ${ctx.hike.name} — ${ctx.hike.region}, ${ctx.hike.country}, ${ctx.hike.year}.`,
+    ctx.takenAt ? `Taken: ${ctx.takenAt}.` : '',
+    `The photo's GPS is nearest these route waypoints: ${cand}.`,
+    `Full route, in order: ${route}.`,
+    `Look at the image file ${imagePath}.`,
+    'Return ONLY a JSON object — no prose, no markdown fence — with EXACTLY these keys:',
+    '{"waypoint": the single best waypoint NAME from the route this photo belongs to (prefer the geo-nearest candidates above, but override when the scene clearly indicates another — e.g. the Matterhorn implies Zermatt; use an exact name from the route list),',
+    `"sceneType": one of [${SCENE_TYPES.join(', ')}],`,
+    '"subjectTags": array of 3-7 short tags (named peaks, features, conditions),',
+    '"caption": one evocative sentence, British spelling; do NOT invent place names you cannot actually identify,',
+    '"alt": a plain factual accessibility description,',
+    '"heroWorthiness": integer 0-10 (how striking/representative as a cover image),',
+    '"quality": integer 0-10 (low for blurry, dark, or accidental shots),',
+    '"skip": true if blurry/accidental/screenshot/duplicate-feeling/not gallery-worthy, else false,',
+    '"reason": a brief why for the waypoint choice and the skip flag}',
+  ].filter(Boolean).join('\n')
+}
+
+/** Pull the first balanced {...} JSON object out of agy's (possibly chatty) output. */
+export function extractJson(text) {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  const body = fenced ? fenced[1] : text
+  const start = body.indexOf('{')
+  if (start < 0) return null
+  let depth = 0
+  for (let i = start; i < body.length; i++) {
+    if (body[i] === '{') depth++
+    else if (body[i] === '}' && --depth === 0) {
+      try {
+        return JSON.parse(body.slice(start, i + 1))
+      } catch {
+        return null
+      }
+    }
+  }
+  return null
+}
+
+function validate(obj, ctx) {
+  if (!obj || typeof obj !== 'object') return null
+  const names = new Set(ctx.waypoints.map((w) => w.name))
+  const clampI = (v) => Math.max(0, Math.min(10, Math.round(Number(v) || 0)))
+  return {
+    waypoint: typeof obj.waypoint === 'string' && names.has(obj.waypoint) ? obj.waypoint : '',
+    sceneType: SCENE_TYPES.includes(obj.sceneType) ? obj.sceneType : 'other',
+    subjectTags: Array.isArray(obj.subjectTags) ? obj.subjectTags.slice(0, 8).map(String) : [],
+    caption: typeof obj.caption === 'string' ? obj.caption.trim() : '',
+    alt: typeof obj.alt === 'string' ? obj.alt.trim() : '',
+    heroWorthiness: clampI(obj.heroWorthiness),
+    quality: clampI(obj.quality),
+    skip: Boolean(obj.skip),
+    reason: typeof obj.reason === 'string' ? obj.reason.trim() : '',
+  }
+}
+
+function runAgy(imageDir, prompt) {
+  const args = ['--add-dir', imageDir, '--dangerously-skip-permissions', '-p', prompt]
+  if (AGY_MODEL) args.push('--model', AGY_MODEL)
+  return new Promise((resolve, reject) => {
+    // stdin MUST be 'ignore' (closed) — agy blocks on an open stdin pipe.
+    const child = spawn(AGY_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    let out = ''
+    let err = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error('agy timed out (5m)'))
+    }, 5 * 60 * 1000)
+    child.stdout.on('data', (d) => { out += d })
+    child.stderr.on('data', (d) => { err += d })
+    child.on('error', (e) => { clearTimeout(timer); reject(e) })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (code !== 0 && !out.trim()) reject(new Error(`agy exit ${code}: ${err.slice(0, 400)}`))
+      else resolve(out)
+    })
+  })
+}
+
+const FAIL = {
+  needsManual: true, waypoint: '', sceneType: 'other', subjectTags: [],
+  caption: '', alt: '', heroWorthiness: 0, quality: 0, skip: false, reason: 'classification failed',
+}
+
+/** Classify one image via agy (one retry on bad JSON). `imagePath` must be inside `imageDir`. */
+export async function classifyImage(imagePath, imageDir, ctx) {
+  const base = buildPrompt(imagePath, ctx)
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let out
+    try {
+      out = await runAgy(imageDir, attempt === 0 ? base : `${base}\n\nReturn ONLY the JSON object and nothing else.`)
+    } catch (e) {
+      if (attempt === 1) return { ...FAIL, reason: e.message.slice(0, 160) }
+      continue
+    }
+    const valid = validate(extractJson(out), ctx)
+    if (valid && (valid.caption || valid.waypoint)) return valid
+  }
+  return { ...FAIL }
+}

--- a/tools/hike-annotate/src/config.mjs
+++ b/tools/hike-annotate/src/config.mjs
@@ -1,0 +1,17 @@
+// Standalone config for the hike photo annotator. The bucket + public base are
+// the site's single image bucket (public-read, not secret). Write auth is the
+// gcloud account that owns the bucket; the Gemini executor is the Antigravity CLI.
+
+export const BUCKET = process.env.HIKE_BUCKET || 'benebsworth-hiking'
+export const PUBLIC_BASE = (process.env.HIKE_PUBLIC_BASE || `https://storage.googleapis.com/${BUCKET}`).replace(/\/$/, '')
+
+// gcloud account with bucket IAM write — pinned, never the ambient active account.
+export const GCLOUD_ACCOUNT = process.env.HIKE_GCLOUD_ACCOUNT || 'ben.ebsworth@gmail.com'
+
+// Antigravity CLI (`agy`) — the Gemini vision executor.
+export const AGY_BIN = process.env.AGY_BIN || 'agy'
+export const AGY_MODEL = process.env.AGY_MODEL || '' // '' = agy default (Gemini 3.x Pro)
+
+export const manifestObject = (slug) => `manifest/hike/${slug}.json`
+export const manifestPublicUrl = (slug) => `${PUBLIC_BASE}/${manifestObject(slug)}`
+export const gsUri = (object) => `gs://${BUCKET}/${object}`

--- a/tools/hike-annotate/src/geo.mjs
+++ b/tools/hike-annotate/src/geo.mjs
@@ -1,0 +1,51 @@
+const R_KM = 6371
+
+const toRad = (d) => (d * Math.PI) / 180
+
+/** Great-circle distance in km between two {lat,lng} points. */
+export function haversineKm(a, b) {
+  const dLat = toRad(b.lat - a.lat)
+  const dLng = toRad(b.lng - a.lng)
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLng / 2) ** 2
+  return 2 * R_KM * Math.asin(Math.min(1, Math.sqrt(s)))
+}
+
+/** Nearest geocoded waypoint to a point. Returns { waypoint, km, ranked }.
+ *  `geoWaypoints` = [{ name, lat, lng, ... }]; entries without finite lat/lng are skipped. */
+export function nearestWaypoint(point, geoWaypoints) {
+  const ranked = geoWaypoints
+    .filter((w) => Number.isFinite(w.lat) && Number.isFinite(w.lng))
+    .map((w) => ({ name: w.name, km: haversineKm(point, w) }))
+    .sort((a, b) => a.km - b.km)
+  return { waypoint: ranked[0]?.name ?? '', km: ranked[0]?.km ?? Infinity, ranked }
+}
+
+/** Day-order index per waypoint name, parsed from "Day N" labels (for chronology). */
+export function dayIndex(geoWaypoints) {
+  const idx = {}
+  geoWaypoints.forEach((w, i) => {
+    const m = /(\d+)/.exec(w.day || '')
+    idx[w.name] = m ? Number(m[1]) : i + 1
+  })
+  return idx
+}
+
+/** Flag photos whose geo-nearest waypoint regresses against takenAt chronology.
+ *  Returns a Set of asset ids that look temporally out of place (low confidence). */
+export function chronologyConflicts(placed, geoWaypoints) {
+  const di = dayIndex(geoWaypoints)
+  const withTime = placed
+    .filter((p) => p.takenAt && p.slot && di[p.slot] != null)
+    .sort((a, b) => String(a.takenAt).localeCompare(String(b.takenAt)))
+  const conflicts = new Set()
+  let maxDay = -Infinity
+  for (const p of withTime) {
+    const d = di[p.slot]
+    // allow same-or-forward; a meaningful backward jump (>1 day) is suspicious
+    if (d < maxDay - 1) conflicts.add(p.id)
+    else maxDay = Math.max(maxDay, d)
+  }
+  return conflicts
+}

--- a/tools/hike-annotate/src/geocode.mjs
+++ b/tools/hike-annotate/src/geocode.mjs
@@ -1,0 +1,67 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const CACHE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../.cache')
+const CACHE_FILE = resolve(CACHE_DIR, 'geocode.json')
+
+// Seed: Walker's Haute Route waypoint town centres. Accurate enough for
+// nearest-neighbour among 8 waypoints 5-20 km apart vs ±50 m photo GPS. Other
+// hikes geocode live via Nominatim (cached).
+const SEED = {
+  Chamonix: { lat: 45.9237, lng: 6.8694 },
+  Trient: { lat: 46.0594, lng: 6.9989 },
+  Champex: { lat: 46.0289, lng: 7.1119 },
+  'Le Châble': { lat: 46.0856, lng: 7.2206 },
+  Arolla: { lat: 46.0277, lng: 7.4836 },
+  Zinal: { lat: 46.1356, lng: 7.6228 },
+  Gruben: { lat: 46.1639, lng: 7.7178 },
+  Zermatt: { lat: 46.0207, lng: 7.7491 },
+}
+
+let cache = null
+async function loadCache() {
+  if (cache) return cache
+  try {
+    cache = JSON.parse(await readFile(CACHE_FILE, 'utf8'))
+  } catch {
+    cache = {}
+  }
+  return cache
+}
+async function saveCache() {
+  await mkdir(CACHE_DIR, { recursive: true })
+  await writeFile(CACHE_FILE, JSON.stringify(cache, null, 2))
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+/** Geocode a place name → { lat, lng } | null. Seed → cache → Nominatim. */
+export async function geocodePlace(name, hint = '') {
+  if (SEED[name]) return SEED[name]
+  const c = await loadCache()
+  const key = `${name}|${hint}`
+  if (key in c) return c[key]
+  const q = encodeURIComponent(hint ? `${name}, ${hint}` : name)
+  const url = `https://nominatim.openstreetmap.org/search?q=${q}&format=json&limit=1`
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'benebsworth-hike-annotate/0.1 (ben.ebsworth@gmail.com)' },
+  })
+  if (!res.ok) throw new Error(`geocode ${name}: HTTP ${res.status}`)
+  const arr = await res.json()
+  const hit = arr[0] ? { lat: parseFloat(arr[0].lat), lng: parseFloat(arr[0].lon) } : null
+  c[key] = hit
+  await saveCache()
+  await sleep(1100) // Nominatim politeness (1 req/s)
+  return hit
+}
+
+/** Geocode an ordered waypoint list → [{ ...waypoint, lat, lng }]. */
+export async function geocodeWaypoints(waypoints, hint = '') {
+  const out = []
+  for (const w of waypoints) {
+    const g = await geocodePlace(w.name, hint)
+    out.push({ ...w, lat: g?.lat ?? NaN, lng: g?.lng ?? NaN })
+  }
+  return out
+}

--- a/tools/hike-annotate/src/manifest.mjs
+++ b/tools/hike-annotate/src/manifest.mjs
@@ -1,0 +1,57 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { GCLOUD_ACCOUNT, PUBLIC_BASE, manifestObject, manifestPublicUrl, gsUri } from './config.mjs'
+
+const pexec = promisify(execFile)
+
+/** Read a hike's ContentManifest { hero?, og?, gallery[] } from the public GCS
+ *  object (cache-busted). Returns an empty manifest on 404. */
+export async function readManifest(slug) {
+  const url = `${manifestPublicUrl(slug)}?t=${Date.now()}`
+  const res = await fetch(url, { cache: 'no-store' })
+  if (res.status === 404) return { hero: undefined, og: undefined, gallery: [] }
+  if (!res.ok) throw new Error(`readManifest(${slug}): HTTP ${res.status}`)
+  const m = await res.json()
+  return { hero: m.hero, og: m.og, gallery: Array.isArray(m.gallery) ? m.gallery : [] }
+}
+
+/** Read the global library registry from the public GCS object. */
+export async function readLibrary() {
+  const url = `${PUBLIC_BASE}/library/index.json?t=${Date.now()}`
+  const res = await fetch(url, { cache: 'no-store' })
+  if (res.status === 404) return []
+  if (!res.ok) throw new Error(`readLibrary: HTTP ${res.status}`)
+  return res.json()
+}
+
+/** Build a hike's working gallery from its manifest plus any assets uploaded
+ *  from that hike (itemType/itemSlug). Keeps manifest order and avoids
+ *  duplicates; newly discovered library assets are appended. */
+export function mergeLibraryAssets(manifest, library, slug) {
+  const seen = new Set((manifest.gallery || []).map((a) => a.id))
+  const extra = (library || []).filter((a) => a.itemType === 'hike' && a.itemSlug === slug && !seen.has(a.id))
+  return [...(manifest.gallery || []), ...extra]
+}
+
+/** Write a ContentManifest back to GCS via gsutil (pinned account; cache-control
+ *  no-store to match the admin so public reads never go stale). Returns the gs:// uri. */
+export async function writeManifest(slug, manifest, tmpDir) {
+  const file = join(tmpDir, `${slug}.write.json`)
+  await writeFile(file, JSON.stringify(manifest))
+  const obj = manifestObject(slug)
+  await pexec(
+    'gsutil',
+    ['-h', 'Cache-Control:no-store', '-h', 'Content-Type:application/json', 'cp', file, gsUri(obj)],
+    { env: { ...process.env, CLOUDSDK_CORE_ACCOUNT: GCLOUD_ACCOUNT } },
+  )
+  return gsUri(obj)
+}
+
+/** Write a timestamped backup of the pre-write manifest locally. */
+export async function backupManifest(slug, manifest, tmpDir, stamp) {
+  const file = join(tmpDir, `${slug}.backup.${stamp}.json`)
+  await writeFile(file, JSON.stringify(manifest, null, 2))
+  return file
+}

--- a/tools/hike-annotate/src/pipeline.mjs
+++ b/tools/hike-annotate/src/pipeline.mjs
@@ -1,0 +1,83 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readManifest, readLibrary, mergeLibraryAssets } from './manifest.mjs'
+import { getWaypoints, getHikeMeta } from './waypoints.mjs'
+import { geocodeWaypoints } from './geocode.mjs'
+import { nearestWaypoint } from './geo.mjs'
+import { classifyImage } from './classify.mjs'
+import { placeAsset, pickHero, orderGallery } from './place.mjs'
+
+/** Run up to `limit` async workers over items. */
+async function mapLimit(items, limit, fn) {
+  const results = new Array(items.length)
+  let next = 0
+  const worker = async () => {
+    while (next < items.length) {
+      const i = next++
+      results[i] = await fn(items[i], i)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length || 1) }, worker))
+  return results
+}
+
+async function downloadThumb(asset, dir) {
+  const url = asset.thumb || asset.url
+  const file = join(dir, `${asset.id}.webp`)
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`download ${asset.id}: HTTP ${res.status}`)
+  await writeFile(file, Buffer.from(await res.arrayBuffer()))
+  return file
+}
+
+/**
+ * Classify + place every gallery photo of a hike. Returns a PROPOSAL — does not
+ * write. `limit` processes only the first N (the rest are kept unchanged); when
+ * limit < total the proposal is `partial` (not safe to write).
+ */
+export async function annotateHike(slug, opts = {}) {
+  const { limit = Infinity, hint = '', concurrency = 4, onProgress = () => {} } = opts
+  const [meta, wps, manifest, library] = await Promise.all([
+    getHikeMeta(slug),
+    getWaypoints(slug),
+    readManifest(slug),
+    readLibrary(),
+  ])
+  const geo = await geocodeWaypoints(wps, hint || meta.country || '')
+  const validNames = new Set(geo.map((w) => w.name))
+
+  // Start from the manifest, then pull in any assets uploaded from this hike
+  // that aren't already assigned (e.g. uploaded via /admin but not yet saved).
+  const workingGallery = mergeLibraryAssets(manifest, library, slug)
+
+  const n = Number.isFinite(limit) ? Math.min(limit, workingGallery.length) : workingGallery.length
+  const toProcess = workingGallery.slice(0, n)
+  const rest = workingGallery.slice(n)
+  const partial = rest.length > 0
+
+  const dir = await mkdtemp(join(tmpdir(), `hike-annotate-${slug}-`))
+  await mapLimit(toProcess, 8, (a) => downloadThumb(a, dir).catch(() => null))
+
+  let done = 0
+  const placed = await mapLimit(toProcess, concurrency, async (asset) => {
+    const geoMatch = asset.lat || asset.lng ? nearestWaypoint({ lat: asset.lat, lng: asset.lng }, geo) : null
+    const candidates = geoMatch
+      ? geoMatch.ranked.slice(0, 3).map((r) => ({ name: r.name, km: +r.km.toFixed(1) }))
+      : geo.slice(0, 4).map((w) => ({ name: w.name, km: 0 }))
+    const ctx = { hike: meta, waypoints: geo, candidates, takenAt: asset.takenAt }
+    const cls = await classifyImage(join(dir, `${asset.id}.webp`), dir, ctx)
+    onProgress(++done, toProcess.length, asset.id, cls)
+    return placeAsset(asset, geoMatch ? { waypoint: geoMatch.waypoint, km: geoMatch.km } : null, cls, validNames)
+  })
+
+  const annotated = placed.map((p) => p.asset)
+  const metas = placed.map((p) => p.meta)
+  const metaById = Object.fromEntries(metas.map((m) => [m.id, m]))
+  const ordered = orderGallery(annotated, metaById)
+  const heroId = pickHero(metas)
+  const heroAsset = heroId ? annotated.find((a) => a.id === heroId) : undefined
+
+  const proposal = { hero: heroAsset || manifest.hero, og: manifest.og, gallery: [...ordered, ...rest] }
+  return { slug, meta, geo, manifest, proposal, metas, metaById, heroId, tmpDir: dir, partial }
+}

--- a/tools/hike-annotate/src/place.mjs
+++ b/tools/hike-annotate/src/place.mjs
@@ -1,0 +1,51 @@
+// Merge geo-match + agy classification into the final annotated Asset (only the
+// schema fields slot/caption/alt are persisted) plus a report sidecar (the rest).
+
+/** Merge one asset. `geoMatch` = { waypoint, km } | null; `cls` = classifyImage result. */
+export function placeAsset(asset, geoMatch, cls, validNames) {
+  const slot = cls.waypoint && validNames.has(cls.waypoint) ? cls.waypoint : geoMatch?.waypoint || ''
+  return {
+    asset: { ...asset, slot, caption: cls.caption || asset.caption, alt: cls.alt || asset.alt },
+    meta: {
+      id: asset.id,
+      slot,
+      geoWaypoint: geoMatch?.waypoint || '',
+      geoKm: geoMatch?.km ?? null,
+      agyWaypoint: cls.waypoint || '',
+      overrode: Boolean(cls.waypoint && geoMatch?.waypoint && cls.waypoint !== geoMatch.waypoint),
+      sceneType: cls.sceneType,
+      subjectTags: cls.subjectTags || [],
+      caption: cls.caption || '',
+      alt: cls.alt || '',
+      quality: cls.quality ?? 0,
+      heroWorthiness: cls.heroWorthiness ?? 0,
+      skip: Boolean(cls.skip),
+      needsManual: Boolean(cls.needsManual),
+      reason: cls.reason || '',
+      landscape: (asset.width || 0) >= (asset.height || 0),
+      thumb: asset.thumb || asset.url,
+      url: asset.url,
+      takenAt: asset.takenAt || '',
+    },
+  }
+}
+
+/** Best hero asset id: highest heroWorthiness*quality among landscape, non-skip, classified. */
+export function pickHero(metas) {
+  const cands = metas.filter((m) => !m.skip && !m.needsManual && m.landscape)
+  if (!cands.length) return null
+  cands.sort((a, b) => b.heroWorthiness * b.quality - a.heroWorthiness * a.quality)
+  return cands[0].heroWorthiness * cands[0].quality > 0 ? cands[0].id : null
+}
+
+/** Order gallery: kept photos chronological; skip/needsManual sink to the end. */
+export function orderGallery(assets, metaById) {
+  return [...assets].sort((a, b) => {
+    const ma = metaById[a.id]
+    const mb = metaById[b.id]
+    const sa = ma.skip || ma.needsManual ? 1 : 0
+    const sb = mb.skip || mb.needsManual ? 1 : 0
+    if (sa !== sb) return sa - sb
+    return String(a.takenAt).localeCompare(String(b.takenAt))
+  })
+}

--- a/tools/hike-annotate/src/proposal-cache.mjs
+++ b/tools/hike-annotate/src/proposal-cache.mjs
@@ -1,0 +1,37 @@
+import { mkdir, writeFile, readFile, copyFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve, join } from 'node:path'
+
+const CACHE = resolve(dirname(fileURLToPath(import.meta.url)), '../.cache/proposals')
+
+/** Persist a proposal so a later write_manifest call can apply it. */
+export async function saveProposal(slug, run, reportPath, stamp) {
+  const dir = join(CACHE, slug)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'proposal.json'), JSON.stringify(run.proposal))
+  await writeFile(join(dir, 'manifest-backup.json'), JSON.stringify(run.manifest, null, 2))
+  await writeFile(join(dir, 'metas.json'), JSON.stringify(run.metas))
+  let reportCopy = reportPath
+  try {
+    reportCopy = join(dir, 'report.html')
+    await copyFile(reportPath, reportCopy)
+  } catch {
+    reportCopy = reportPath
+  }
+  await writeFile(
+    join(dir, 'meta.json'),
+    JSON.stringify({ slug, partial: run.partial, heroId: run.heroId, reportPath: reportCopy, savedAt: stamp }),
+  )
+  return { dir, reportPath: reportCopy }
+}
+
+/** Load a previously saved proposal (or throw if none). */
+export async function loadProposal(slug) {
+  const dir = join(CACHE, slug)
+  const [proposal, manifest, meta] = await Promise.all([
+    readFile(join(dir, 'proposal.json'), 'utf8').then(JSON.parse),
+    readFile(join(dir, 'manifest-backup.json'), 'utf8').then(JSON.parse),
+    readFile(join(dir, 'meta.json'), 'utf8').then(JSON.parse),
+  ])
+  return { proposal, manifest, ...meta, dir }
+}

--- a/tools/hike-annotate/src/report.mjs
+++ b/tools/hike-annotate/src/report.mjs
@@ -1,0 +1,65 @@
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const esc = (s) =>
+  String(s ?? '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]))
+
+function card(m, heroId) {
+  const badges = [
+    m.id === heroId ? '<span class="hero">HERO</span>' : '',
+    m.skip ? '<span class="b warn">skip</span>' : '',
+    m.needsManual ? '<span class="b warn">manual</span>' : '',
+    m.overrode ? `<span class="b ov">scene≠geo</span>` : '',
+    `<span class="b">q${m.quality}</span>`,
+    `<span class="b">h${m.heroWorthiness}</span>`,
+    `<span class="b">${esc(m.sceneType)}</span>`,
+  ].join('')
+  const geo = `${m.geoWaypoint || '—'}${m.geoKm != null ? ` ${m.geoKm.toFixed(1)}km` : ''}`
+  const when = m.takenAt ? esc(m.takenAt.slice(0, 16).replace('T', ' ')) : ''
+  return `<figure class="${m.skip || m.needsManual ? 'dim' : ''}">
+  <img src="${esc(m.thumb)}" loading="lazy" alt="">
+  <figcaption>
+    <div class="badges">${badges}</div>
+    <p class="cap">${esc(m.caption) || '<em>(no caption)</em>'}</p>
+    <p class="tags">${(m.subjectTags || []).map((t) => `<span>${esc(t)}</span>`).join('')}</p>
+    <p class="meta">geo: ${esc(geo)}${when ? ` · ${when}` : ''}</p>
+    <p class="alt">${esc(m.alt)}</p>
+  </figcaption></figure>`
+}
+
+/** Write a self-contained HTML review report grouped by placed waypoint (route order). */
+export async function writeReport({ slug, meta, geo, metas, heroId, tmpDir, partial }) {
+  const order = geo.map((w) => w.name)
+  const groups = {}
+  for (const m of metas) (groups[m.slot || '(unplaced)'] ||= []).push(m)
+  const names = [...order.filter((n) => groups[n]), ...Object.keys(groups).filter((n) => !order.includes(n))]
+  const sections = names
+    .map(
+      (n) =>
+        `<section><h2>${esc(n)} <small>${groups[n].length} photo${groups[n].length === 1 ? '' : 's'}</small></h2>` +
+        `<div class="grid">${groups[n].map((m) => card(m, heroId)).join('')}</div></section>`,
+    )
+    .join('')
+  const skips = metas.filter((m) => m.skip).length
+  const manual = metas.filter((m) => m.needsManual).length
+  const html = `<!doctype html><html><head><meta charset="utf-8"><title>${esc(meta.name)} — photo placement proposal</title>
+<style>
+:root{color-scheme:dark}body{font:14px/1.5 system-ui,sans-serif;margin:0;background:#0b0b0d;color:#e9e9ee}
+header{padding:18px 22px;border-bottom:1px solid #26262c}h1{margin:0 0 4px;font-size:20px}.sub{color:#9a9aa2;font:13px monospace}
+h2{margin:0;padding:8px 22px;border-top:1px solid #26262c;background:#141419;position:sticky;top:0;z-index:1;font-size:15px}h2 small{color:#7a7a82;font-weight:400}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:14px;padding:16px 22px}
+figure{margin:0;background:#15151a;border:1px solid #26262c;border-radius:10px;overflow:hidden}figure.dim{opacity:.5}
+img{width:100%;height:155px;object-fit:cover;display:block;background:#222}
+figcaption{padding:9px 11px}.badges{display:flex;gap:4px;flex-wrap:wrap;margin-bottom:5px}
+.b,.hero{font:11px ui-monospace,monospace;padding:1px 6px;border-radius:10px}.b{background:#26262e;color:#a8a8b2}
+.hero{background:#1f6f4f;color:#c3ffe6}.warn{background:#6f3a1f;color:#ffd9bf}.ov{background:#3a2f6f;color:#dcd2ff}
+.cap{margin:4px 0;font-weight:600;color:#f2f2f6}.tags{margin:3px 0;display:flex;gap:4px;flex-wrap:wrap}.tags span{font:11px monospace;color:#8a8a94;background:#1d1d23;padding:0 5px;border-radius:8px}
+.meta{margin:3px 0;color:#8a8a94;font:12px ui-monospace,monospace}.alt{margin:5px 0 0;color:#70707a;font-size:12px}
+</style></head><body>
+<header><h1>${esc(meta.name)} — photo placement proposal${partial ? ' (PARTIAL / trial)' : ''}</h1>
+<div class="sub">${metas.length} photos · hero: ${esc(heroId || 'none')} · ${skips} flagged skip · ${manual} need manual · slug: ${esc(slug)}</div></header>
+${sections}</body></html>`
+  const file = join(tmpDir, 'report.html')
+  await writeFile(file, html)
+  return file
+}

--- a/tools/hike-annotate/src/waypoints.mjs
+++ b/tools/hike-annotate/src/waypoints.mjs
@@ -1,0 +1,35 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const pexec = promisify(execFile)
+// src/ -> hike-annotate -> tools -> repo root
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const HIKING_URL = pathToFileURL(resolve(REPO_ROOT, 'content/hiking.ts')).href
+
+// content/hiking.ts is TypeScript whose only import is type-only (erased by
+// --experimental-strip-types), so a child `node` can import it with no aliasing.
+async function evalHike(slug, pick) {
+  const code =
+    `import { getHike } from ${JSON.stringify(HIKING_URL)};` +
+    `const h = getHike(${JSON.stringify(slug)});` +
+    `if(!h){process.stderr.write('no hike: '+${JSON.stringify(slug)});process.exit(2);}` +
+    `process.stdout.write(JSON.stringify(${pick}));`
+  const { stdout } = await pexec(
+    'node',
+    ['--experimental-strip-types', '--input-type=module', '-e', code],
+    { env: process.env, maxBuffer: 8 * 1024 * 1024 },
+  )
+  return JSON.parse(stdout)
+}
+
+/** Ordered waypoints for a hike: [{ name, elev, day, note, x, y }]. */
+export function getWaypoints(slug) {
+  return evalHike(slug, 'h.waypoints.map(w=>({name:w.name,elev:w.elev,day:w.day,note:w.note,x:w.x,y:w.y}))')
+}
+
+/** Lightweight hike metadata for prompt context. */
+export function getHikeMeta(slug) {
+  return evalHike(slug, '({name:h.name,region:h.region,country:h.country,year:h.year,summary:h.summary,accent:h.accent})')
+}


### PR DESCRIPTION
## Summary
- publish the Overland Track winter guide and link it from the hiking overview
- namespace admin uploads by item and add optional asset ownership metadata for the annotation pipeline
- add the hike photo annotation skill/tooling restored from the prior annotator work
- add Playwright coverage for the published guide/hike drilldown

## Validation
- npm run typecheck
- npm test
- npm run lint (warnings only)
- npm run build
- npm run e2e -- e2e/overland-track-guide.spec.ts
- node tools/hike-annotate/scripts/geomatch-dry.mjs overland-track "Tasmania Australia"